### PR TITLE
New dependency on Linux

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,5 @@ README.md
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^windows
+^packrat/
+^\.Rprofile$

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ inst/proj/
 src/Makevars
 config.log
 config.status
+packrat/lib*/
+packrat/src/

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To install these on Ubuntu you can do:
 ```
 sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
 sudo apt-get update
-sudo apt-get install libgdal-dev libgeos-dev libproj-dev 
+sudo apt-get install libgdal-dev libgeos-dev libgeos++-dev libproj-dev 
 ```
 
 And now, in R, install the packages.


### PR DESCRIPTION
The new geos functions requires libgeos++-dev on linux to get the correct header files. Also added a few lines to the gitignore and Rbuildignore that make life easier when using Rstudio to build.