### PR TITLE
remove GFortran before installing GDAL in pkgdown

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -18,9 +18,10 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      - name: "[macOS] Install gdal"
-        if: runner.os == 'macOS'
-        run: brew install gdal
+      - name: Install GDAL
+        run: |
+          rm '/usr/local/bin/gfortran'
+          brew install gdal
 
       - name: Query dependencies
         run: |


### PR DESCRIPTION
Website building by `pkgdown` workflow hasn't been working for several days (https://github.com/rspatial/terra/actions/workflows/pkgdown.yml). The error occur when installing GDAL and is related to linking to GFortran. The proposed solution is to remove GFortran, so I did. After that, `pkgdown` works fine. 

```
==> Installing gdal dependency: gcc
==> Pouring gcc--11.1.0.catalina.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/gfortran
Target /usr/local/bin/gfortran
already exists. You may want to remove it:
  rm '/usr/local/bin/gfortran'

To force the link and overwrite all conflicting files:
  brew link --overwrite gcc

To list all files that would be deleted:
  brew link --overwrite --dry-run gcc

Possible conflicting files are:
/usr/local/bin/gfortran -> /usr/local/gfortran/bin/gfortran
```