### PR TITLE
Install proj in pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -18,10 +18,10 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      - name: Install GDAL
+      - name: Install spatial dependencies
         run: |
           rm '/usr/local/bin/gfortran'
-          brew install gdal
+          brew install gdal proj
 
       - name: Query dependencies
         run: |


### PR DESCRIPTION
`pkgdown` workflow [fails](https://github.com/rspatial/terra/actions/workflows/pkgdown.yml) in some cases due to the below error. Explicitly specifying `proj` for installation should fix this problem. 

```
checking proj.h usability... no
checking proj.h presence... no
checking for proj.h... no
checking proj_api.h usability... no
checking proj_api.h presence... no
checking for proj_api.h... no
configure: error: proj_api.h not found in standard or given locations.
ERROR: configuration failed for package ‘terra’
```