### PR TITLE
fix incorrect to_id in nearest()

### DIFF
--- a/R/relate.R
+++ b/R/relate.R
@@ -188,6 +188,7 @@ setMethod("nearest", signature(x="SpatVector"),
 			values(to) <- data.frame(id=1:nrow(to))
 			values(y) <- data.frame(to_id=1:nrow(y))
 			to_int <- as.data.frame(intersect(to, y))
+			to_int <- to_int[order(to_int[["id"]]), ]
 			if (nrow(to_int) > nrow(to)) {
 				to_int <- aggregate(to_int[, "to_id",drop=FALSE], to_int[,"id",drop=FALSE], function(x)x[1]) 
 			} 


### PR DESCRIPTION
I believe this fixes issue #328 . `to_int <- as.data.frame(intersect(to, y))` results in a data frame that is out of order with respect to the input data frame `to`, causing incorrect `to_id` in the output of `nearest()`. I suspect there may be a better approach here, mostly submitting this PR to point to where the issue is occurring.