### PR TITLE
Avoid dangling GDAL dataset

### DIFF
--- a/src/read_gdal.cpp
+++ b/src/read_gdal.cpp
@@ -402,6 +402,7 @@ bool SpatRaster::constructFromFile(std::string fname, std::vector<int> subds, st
 			for (size_t i=0; metadata[i] != NULL; i++) {
 				meta.push_back(metadata[i]);
 			}
+			GDALClose( (GDALDatasetH) poDataset );
 			return constructFromSDS(fname, meta, subds, subdsname, options, gdrv=="netCDF"); 
 		} else {
 			setError("no data detected in " + fname);


### PR DESCRIPTION
When processing many files in a loop, this leak eventually causes R to crash because too many files are open. Using managed pointers (`std::unique_ptr`, `std::shared_ptr`) with a custom deleter would also avoid this.