### PR TITLE
Add functions to check and set GDAL cache size

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -7,5 +7,5 @@ exportMethods("[", "[[", "!", "%in%", activeCat, "activeCat<-", "add<-", adjacen
 S3method(cbind, SpatVector)
 S3method(rbind, SpatVector)
 
-export(focalMat, gdal, sbar, terraOptions, tmpFiles, mem_info, free_RAM, shade)
+export(focalMat, gdal, sbar, terraOptions, tmpFiles, mem_info, free_RAM, shade, setGDALCacheSizeMB, getGDALCacheSizeMB)
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -57,3 +57,11 @@
     .Call(`_terra_percRank`, x, y, minc, maxc, tail)
 }
 
+setGDALCacheSizeMB <- function(x) {
+    invisible(.Call(`_terra_setGDALCacheSizeMB`, x))
+}
+
+getGDALCacheSizeMB <- function() {
+    .Call(`_terra_getGDALCacheSizeMB`)
+}
+

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -167,6 +167,26 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// setGDALCacheSizeMB
+void setGDALCacheSizeMB(double x);
+RcppExport SEXP _terra_setGDALCacheSizeMB(SEXP xSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< double >::type x(xSEXP);
+    setGDALCacheSizeMB(x);
+    return R_NilValue;
+END_RCPP
+}
+// getGDALCacheSizeMB
+double getGDALCacheSizeMB();
+RcppExport SEXP _terra_getGDALCacheSizeMB() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(getGDALCacheSizeMB());
+    return rcpp_result_gen;
+END_RCPP
+}
 
 RcppExport SEXP _rcpp_module_boot_spat();
 
@@ -185,6 +205,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_terra_set_gdal_warnings", (DL_FUNC) &_terra_set_gdal_warnings, 1},
     {"_terra_gdal_init", (DL_FUNC) &_terra_gdal_init, 1},
     {"_terra_percRank", (DL_FUNC) &_terra_percRank, 5},
+    {"_terra_setGDALCacheSizeMB", (DL_FUNC) &_terra_setGDALCacheSizeMB, 1},
+    {"_terra_getGDALCacheSizeMB", (DL_FUNC) &_terra_getGDALCacheSizeMB, 0},
     {"_rcpp_module_boot_spat", (DL_FUNC) &_rcpp_module_boot_spat, 0},
     {NULL, NULL, 0}
 };

--- a/src/RcppFunctions.cpp
+++ b/src/RcppFunctions.cpp
@@ -348,3 +348,12 @@ std::vector<double> percRank(std::vector<double> x, std::vector<double> y, doubl
 }
 
 
+// [[Rcpp::export()]]
+void setGDALCacheSizeMB(double x) {
+  GDALSetCacheMax64(static_cast<int64_t>(x) * 1024 * 1024);
+}
+
+// [[Rcpp::export()]]
+double getGDALCacheSizeMB() {
+  return static_cast<double>(GDALGetCacheMax64() / 1024 / 1024);
+}


### PR DESCRIPTION
This PR adds functions to check and set the GDAL cache size. I'm not sure if it's a good idea to expose low-level functionality like this in terra, and I'm curious what you think.

My motivation for doing so is to detect situations where `exactextractr` will perform poorly. I am working with a netCDF dataset that uses a very large chunk size. If I simultaneously extract from 1000 bands of the dataset it takes a few seconds, but increasing this to 1100 bands increases the runtime to 10-15 minutes. The reason is that the last 100 bands push us over the limit of GDAL's block cache, so every band is decompressed with for every feature that I'm extracting. Since I can anticipate memory requirements before the operation, I could throw a warning and direct the user to increase the cache size or reduce the number of bands for better performance.

Without modifying terra, it is possible to set the cache size using `Sys.setenv(GDAL_CACHEMAX=something)`. But this only works if it is called after starting R and before reading any values with terra. After values have been read from any raster, the environment variable is ignored. And there is no mechanism to query the cache size either.




