### PR TITLE
x can be a SpatRaster

### DIFF
--- a/man/project.Rd
+++ b/man/project.Rd
@@ -17,7 +17,7 @@ Change the coordinate reference system ("project") of a SpatVector or SpatRaster
 }
 
 \arguments{
-  \item{x}{SpatVector}
+  \item{x}{SpatRaster or SpatVector}
   \item{y}{if (\code{x} is a SpatRaster, the prefered approach is for \code{y} to be a SpatRaster as well, serving as a template for the geometry (extent and resolution) of the output SpatRaster. Alternatively, you can provide a coordinate reference system (crs) description. 
     
   You can use the following formats to define coordinate reference systems: WKT,  PROJ.4 (e.g., \code{+proj=longlat +datum=WGS84}), or an EPSG code (e.g., \code{"epsg:4326"}). But note that the PROJ.4 notation has been deprecated, and you can only use if with the WGS84/NAD83 and NAD27 datums. Other datums are silently ignored. 


### PR DESCRIPTION
For project(), x can also be a SpatRaster, but the current documentation only says "SpatVector".