### PR TITLE
Add test for SpatExtent intersection

### DIFF
--- a/inst/tinytest/test_extent.R
+++ b/inst/tinytest/test_extent.R
@@ -1,0 +1,4 @@
+# intersection of disjoint envelopes is NULL
+a <- ext(c(xmin = 0, xmax = 10, ymin = 0, ymax = 10))
+b <- ext(c(xmin = 100, xmax = 101, ymin = 100, ymax = 101))
+expect_null(intersect(a, b))


### PR DESCRIPTION
The behavior here changed recently, so I thought it would be good to add a test to pin it down.