### PR TITLE
typo: man page for writeRaster.Rd was missing \ in \link

### DIFF
--- a/man/writeRaster.Rd
+++ b/man/writeRaster.Rd
@@ -47,7 +47,7 @@ In writeRaster, and in other methods that generate SpatRaster objects, options f
 
 \code{memfrac}\tab numeric between 0 and 0.9 (higher values give a warning). The fraction of available RAM that terra is allowed to use.\cr
 
-\code{memmax}\tab memmax - the maximum amount of RAM (in GB) that terra can use when processing a raster dataset. Should be less than what is detected (see \code{link{mem_info}}, and higher values are ignored. Set it to a negative number or NA to ignore this value). \cr
+\code{memmax}\tab memmax - the maximum amount of RAM (in GB) that terra can use when processing a raster dataset. Should be less than what is detected (see \code{\link{mem_info}}, and higher values are ignored. Set it to a negative number or NA to ignore this value). \cr
 
 \code{names}\tab output layer names.\cr
 


### PR DESCRIPTION
small typo in \link