### PR TITLE
Fix handling of categories in SpatRaster with multiple layers

### DIFF
--- a/R/levels.R
+++ b/R/levels.R
@@ -280,7 +280,7 @@ active_cats <- function(x, layer) {
 	}
 	cats <- x@ptr$getCategories()
 	x <- lapply(1:length(cats), function(i) {
-		if (cats[[1]]$df$nrow == 0) return(NULL)
+		if (cats[[i]]$df$nrow == 0) return(NULL)
 		r <- .getSpatDF(cats[[i]]$df)
 		a <- activeCat(x, i)
 		r[, c(1, a+1)]

--- a/R/show.R
+++ b/R/show.R
@@ -302,7 +302,7 @@ setMethod ("show" , "SpatRaster",
 							cats <- cats[j, 2]
 							if (length(cats) > 0) {
 								minv[i] <- cats[1]
-								maxv[i] <- cats[1]
+								maxv[i] <- cats[2]
 							}
 						} 
 					}

--- a/R/show.R
+++ b/R/show.R
@@ -298,11 +298,11 @@ setMethod ("show" , "SpatRaster",
 						if (i > mnr) break
 						if (isf[i]) {
 							cats <- cats(object, i, TRUE)[[1]]
-							j <- match(c(minv, maxv), cats[,1])
+							j <- match(c(minv[i], maxv[i]), cats[,1])
 							cats <- cats[j, 2]
 							if (length(cats) > 0) {
 								minv[i] <- cats[1]
-								maxv[i] <- cats[2]
+								maxv[i] <- cats[1]
 							}
 						} 
 					}
@@ -311,7 +311,7 @@ setMethod ("show" , "SpatRaster",
 				wln <- nchar(ln)
 				if (any(u8)) {
 					# for Chinese: wln <- wln + u8 * wln
-					w <- pmax(wln, nchar(minv), nchar(maxv), nchar(uts))
+					w <- pmax(wln, nchar(minv), nchar(maxv), nchar(uts), na.rm = TRUE)
 					m <- rbind(paste0(rep(" ", max(wln)), collapse=""), minv, maxv)
 					if (hasunits) m <- rbind(m, uts)
 					# a loop because "width" is not recycled by format
@@ -321,7 +321,7 @@ setMethod ("show" , "SpatRaster",
 						m[1,i] <- paste0(paste0(rep(" ", addsp), collapse=""), ln[i])
 					}
 				} else {
-					w <- pmax(wln, nchar(minv), nchar(maxv), nchar(uts))
+					w <- pmax(wln, nchar(minv), nchar(maxv), nchar(uts), na.rm = TRUE)
 					m <- rbind(ln, minv, maxv)
 					if (hasunits) m <- rbind(m, uts)
 					# a loop because "width" is not recycled by format

--- a/inst/tinytest/test_cats.R
+++ b/inst/tinytest/test_cats.R
@@ -2,6 +2,9 @@
 set.seed(0)
 r <- rast(nrows=10, ncols=10)
 values(r) <- sample(3, ncell(r), replace=TRUE) - 1
+r0 <- r
+
+# categories in a single layer
 lv <- c("forest", "water", "urban")
 levels(r) <- lv
 names(r) <- "land cover"
@@ -11,15 +14,45 @@ v <- cats(r)[[1]]
 expect_equal(v$value, 0:2)
 expect_equal(v$category, lv)
 
+# reading/writing categories 
 ftmp <- tempfile(fileext = ".tif")
 z <- writeRaster(r, ftmp, overwrite=TRUE)
 v <- cats(z)[[1]]
 expect_equal(v$value, 0:2)
 expect_equal(v$`land cover`, lv)
 
+# reading/writing subset of categories 
 levels(r) = cats(r)[[1]][2:3,]
 zz = writeRaster(r, ftmp, overwrite=TRUE)
 v <- cats(zz)[[1]]
 
 expect_equal(v$value, 1:2)
 expect_equal(v$category, lv[-1])
+
+# categories in multiple layers
+r2 <- rast(list(a=r0, b=r0))
+
+# avoid warnings related to assumed lon/lat 
+crs(r2) <- "EPSG:4326"
+
+# values are numeric initially
+expect_equal(values(r2)[1,], c(a = 1, b = 1))
+
+# set layer a categories
+levels(r2) <- lv
+expect_equal(levels(r2), list(lv, ""))
+
+# verify samples for layer a have categories
+set.seed(0)
+expect_equal(spatSample(r2, 2), data.frame(a = factor(c("forest", "forest"), levels = lv), 
+                                           b = c(0, 0)))
+
+# set all layer categories
+levels(r2) <- rep(list(lv), 2)
+expect_equal(levels(r2), list(lv, lv))
+
+# verify samples for layer a and layer b have categories
+set.seed(1)
+expect_equal(spatSample(r2, 2), data.frame(a = factor(c("forest", "water"), levels = lv),
+                                           b = factor(c("forest", "water"), levels = lv)))
+

--- a/inst/tinytest/test_cats.R
+++ b/inst/tinytest/test_cats.R
@@ -56,3 +56,5 @@ set.seed(1)
 expect_equal(spatSample(r2, 2), data.frame(a = factor(c("forest", "water"), levels = lv),
                                            b = factor(c("forest", "water"), levels = lv)))
 
+# make sure no errors when show()ing factors
+expect_silent(show(r2))


### PR DESCRIPTION
This PR fixes `active_cats()`and `show(<SpatRaster>)` to achieve the expected behavior from my issue #563:

``` r
library(terra)
#> terra 1.5.23

x <- rast(lapply(1:3, \(i) set.crs(rast(matrix(round(runif(33 ^ 2, 0, 2)), 33, 33)), "EPSG:4326")))

set.seed(123)
spatSample(x, 3)
#>   lyr.1 lyr.1.1 lyr.1.2
#> 1     2       1       1
#> 2     2       1       2
#> 3     0       1       2
levels(x) <- LETTERS[1:3]
set.seed(123)
spatSample(x, 3)
#>   lyr.1 lyr.1.1 lyr.1.2
#> 1     C       1       1
#> 2     C       1       2
#> 3     A       1       2

levels(x) <- rep(list(LETTERS[1:3]), 3)
set.seed(123)
spatSample(x, 3)
#>   lyr.1 lyr.1.1 lyr.1.2
#> 1     C       B       B
#> 2     C       B       C
#> 3     A       B       C

show(x)
#> class       : SpatRaster 
#> dimensions  : 33, 33, 3  (nrow, ncol, nlyr)
#> resolution  : 1, 1  (x, y)
#> extent      : 0, 33, 0, 33  (xmin, xmax, ymin, ymax)
#> coord. ref. : lon/lat WGS 84 (EPSG:4326) 
#> sources     : memory  
#>               memory  
#>               memory  
#> names       : lyr.1, lyr.1, lyr.1 
#> min values  :     A,     A,     A 
#> max values  :     C,     C,     C
```

Current behavior:
``` r
library(terra)
#> terra 1.5.23

x <- rast(lapply(1:3, \(i) set.crs(rast(matrix(round(runif(33 ^ 2, 0, 2)), 33, 33)), "EPSG:4326")))

set.seed(123)
spatSample(x, 3)
#>   lyr.1 lyr.1.1 lyr.1.2
#> 1     2       1       0
#> 2     1       1       0
#> 3     2       2       1

levels(x) <- LETTERS[1:3]
set.seed(123)
spatSample(x, 3)
#> Error in `[.data.frame`(r, , c(1, a + 1)): undefined columns selected

levels(x) <- rep(list(LETTERS[1:3]), 3)
set.seed(123)
spatSample(x, 3)
#>   lyr.1 lyr.1.1 lyr.1.2
#> 1     C       B       A
#> 2     B       B       A
#> 3     C       C       B

show(x)
#> class       : SpatRaster 
#> dimensions  : 33, 33, 3  (nrow, ncol, nlyr)
#> resolution  : 1, 1  (x, y)
#> extent      : 0, 33, 0, 33  (xmin, xmax, ymin, ymax)
#> coord. ref. : lon/lat WGS 84 (EPSG:4326) 
#> sources     : memory  
#>               memory  
#>               memory
#> Error in format.default(m[, i], width = w[i], justify = "right"): invalid 'width' argument
```

