### PR TITLE
protect test_wkt_grd from GDAL < 2.3.0

### DIFF
--- a/inst/tinytest/test_wkt_grd.R
+++ b/inst/tinytest/test_wkt_grd.R
@@ -1,13 +1,15 @@
-fl <- system.file("ex/test.grd", package="terra")
-tst <- terra::rast(fl)
-terra::crs(tst) <- "EPSG:28992"
-tf <- tempfile(fileext=".grd")
-terra::writeRaster(tst, tf)
-tst1 <- terra::rast(tf)
-if (gdal() > "3.4.2") {
+if (terra::gdal() >= "2.3.0") {
+  fl <- system.file("ex/test.grd", package="terra")
+  tst <- terra::rast(fl)
+  terra::crs(tst) <- "EPSG:28992"
+  tf <- tempfile(fileext=".grd")
+  terra::writeRaster(tst, tf)
+  tst1 <- terra::rast(tf)
+  if (terra::gdal() > "3.4.2") {
     expect_identical(terra::crs(tst, describe=TRUE)[1:3],
         terra::crs(tst1, describe=TRUE)[1:3])
-} else {
+  } else {
     expect_false(isTRUE(all.equal(terra::crs(tst, describe=TRUE)[1:3],
         terra::crs(tst1, describe=TRUE)[1:3])))
+  }
 }


### PR DESCRIPTION
This runs the test only for GDAL >= 2.3.0, I hope it covers the needs - I've only tested on 2.2.4.