### PR TITLE
default row/col for xFromCol,yFromRow if missing

### DIFF
--- a/R/xyRowColCell.R
+++ b/R/xyRowColCell.R
@@ -3,19 +3,32 @@
 # Version 1.0
 # License GPL v3
 
-setMethod("yFromRow", signature(object="SpatRaster", row="numeric"), 
+setMethod("yFromRow", signature(object="SpatRaster", row="numeric"),
 	function(object, row) {
 		object@ptr$yFromRow(row - 1)
 	}
 )
 
-setMethod(xFromCol, signature(object="SpatRaster", col="numeric"), 
-	function(object, col) {
-		object@ptr$xFromCol(col - 1)
-	}  
+setMethod("yFromRow", signature(object="SpatRaster", row="missing"),
+	function(object, row) {
+	  row <- seq_len(object@ptr$nrow())
+		object@ptr$yFromRow(row - 1)
+	}
 )
 
-setMethod(colFromX, signature(object="SpatRaster", x="numeric"), 
+setMethod(xFromCol, signature(object="SpatRaster", col="numeric"),
+	function(object, col) {
+		object@ptr$xFromCol(col - 1)
+	}
+)
+setMethod(xFromCol, signature(object="SpatRaster", col="missing"),
+	function(object, col) {
+	  col <- seq_len(object@ptr$ncol())
+		object@ptr$xFromCol(col - 1)
+	}
+)
+
+setMethod(colFromX, signature(object="SpatRaster", x="numeric"),
 	function(object, x)	{
 		cols <- object@ptr$colFromX(x) + 1
 		cols[cols==0] <- NA
@@ -23,7 +36,7 @@ setMethod(colFromX, signature(object="SpatRaster", x="numeric"),
 	}
 )
 
-setMethod(rowFromY, signature(object="SpatRaster", y="numeric"), 
+setMethod(rowFromY, signature(object="SpatRaster", y="numeric"),
 	function(object, y)	{
 		rows <- object@ptr$rowFromY(y) + 1
 		rows[rows==0] <- NA
@@ -31,7 +44,7 @@ setMethod(rowFromY, signature(object="SpatRaster", y="numeric"),
 	}
 )
 
-setMethod(cellFromXY, signature(object="SpatRaster", xy="matrix"), 
+setMethod(cellFromXY, signature(object="SpatRaster", xy="matrix"),
 	function(object, xy) {
 		stopifnot(ncol(xy) == 2)
 		#.checkXYnames(colnames(xy))
@@ -39,7 +52,7 @@ setMethod(cellFromXY, signature(object="SpatRaster", xy="matrix"),
 	}
 )
 
-setMethod(cellFromXY, signature(object="SpatRaster", xy="data.frame"), 
+setMethod(cellFromXY, signature(object="SpatRaster", xy="data.frame"),
 	function(object, xy) {
 		stopifnot(ncol(xy) == 2)
 		#.checkXYnames(colnames(xy))
@@ -49,20 +62,20 @@ setMethod(cellFromXY, signature(object="SpatRaster", xy="data.frame"),
 
 
 
-setMethod(cellFromRowCol, signature(object="SpatRaster", row="numeric", col="numeric"), 
+setMethod(cellFromRowCol, signature(object="SpatRaster", row="numeric", col="numeric"),
 	function(object, row, col) {
 		object@ptr$cellFromRowCol(row-1, col-1) + 1
 	}
 )
 
-setMethod(cellFromRowColCombine, signature(object="SpatRaster", row="numeric", col="numeric"), 
+setMethod(cellFromRowColCombine, signature(object="SpatRaster", row="numeric", col="numeric"),
 	function(object, row, col) {
 		object@ptr$cellFromRowColCombine(row-1, col-1) + 1
 	}
 )
 
 
-setMethod(xyFromCell, signature(object="SpatRaster", cell="numeric"), 
+setMethod(xyFromCell, signature(object="SpatRaster", cell="numeric"),
 	function(object, cell) {
 		xy <- object@ptr$xyFromCell(cell-1)
 		xy <- do.call(cbind, xy)
@@ -71,20 +84,20 @@ setMethod(xyFromCell, signature(object="SpatRaster", cell="numeric"),
 	}
 )
 
-setMethod(yFromCell, signature(object="SpatRaster", cell="numeric"), 
+setMethod(yFromCell, signature(object="SpatRaster", cell="numeric"),
 	function(object, cell) {
 		xyFromCell(object, cell)[,2]
-	}  
+	}
 
 )
 
-setMethod(xFromCell, signature(object="SpatRaster", cell="numeric"), 
+setMethod(xFromCell, signature(object="SpatRaster", cell="numeric"),
 	function(object, cell) {
 		xyFromCell(object, cell)[,1]
-	}  
+	}
 )
 
-setMethod(rowColFromCell, signature(object="SpatRaster", cell="numeric"), 
+setMethod(rowColFromCell, signature(object="SpatRaster", cell="numeric"),
 	function(object, cell) {
 		rc <- object@ptr$rowColFromCell(cell-1)
 		rc <- do.call(cbind, rc)
@@ -93,13 +106,13 @@ setMethod(rowColFromCell, signature(object="SpatRaster", cell="numeric"),
 	}
 )
 
-setMethod(rowFromCell, signature(object="SpatRaster", cell="numeric"), 
+setMethod(rowFromCell, signature(object="SpatRaster", cell="numeric"),
 	function(object, cell) {
 		rowColFromCell(object, cell)[,1]
 	}
 )
 
-setMethod(colFromCell, signature(object="SpatRaster", cell="numeric"), 
+setMethod(colFromCell, signature(object="SpatRaster", cell="numeric"),
 	function(object, cell) {
 		rowColFromCell(object, cell)[,2]
 	}

--- a/man/xyCellFrom.Rd
+++ b/man/xyCellFrom.Rd
@@ -2,8 +2,10 @@
 
 \alias{xFromCol}
 \alias{xFromCol,SpatRaster,numeric-method}
+\alias{xFromCol,SpatRaster,missing-method}
 \alias{yFromRow}
 \alias{yFromRow,SpatRaster,numeric-method}
+\alias{yFromRow,SpatRaster,missing-method}
 \alias{xyFromCell}
 \alias{xyFromCell,SpatRaster,numeric-method}
 \alias{xFromCell}
@@ -28,7 +30,7 @@
 \alias{rowColFromCell}
 \alias{rowColFromCell,SpatRaster,numeric-method}
 
-  
+
 \title{Coordinates from a row, column or cell number and vice versa}
 
 \description{
@@ -43,7 +45,11 @@ row numbers start at 1 at the top, column numbers start at 1 at the left.
 \usage{
 \S4method{xFromCol}{SpatRaster,numeric}(object, col)
 
+\S4method{xFromCol}{SpatRaster,missing}(object)
+
 \S4method{yFromRow}{SpatRaster,numeric}(object, row)
+
+\S4method{yFromRow}{SpatRaster,missing}(object)
 
 \S4method{xyFromCell}{SpatRaster,numeric}(object, cell)
 
@@ -78,16 +84,16 @@ row numbers start at 1 at the top, column numbers start at 1 at the left.
   \item{y}{y coordinate(s)}
   \item{xy}{matrix of x and y coordinates}
 }
-  
+
 \details{
 Cell numbers start at 1 in the upper left corner, and increase from left to right, and then from top to bottom.
 The last cell number equals the number of cells of the SpatRaster (see \code{\link{ncell}}).
 }
 
 \value{
-xFromCol, yFromCol, xFromCell, yFromCell: vector of x or y coordinates 
+xFromCol, yFromCol, xFromCell, yFromCell: vector of x or y coordinates
 
-xyFromCell: matrix(x,y) with coordinate pairs 
+xyFromCell: matrix(x,y) with coordinate pairs
 
 colFromX, rowFromY, cellFromXY, cellFromRowCol, rowFromCell, colFromCell: vector of row, column, or cell numbers
 
@@ -96,7 +102,7 @@ rowColFromCell: matrix of row and column numbers
 
 
 \seealso{
-\code{\link{crds}} 
+\code{\link{crds}}
 }
 
 
@@ -113,13 +119,17 @@ cellFromRowCol(r, 5, 5)
 cellFromRowCol(r, 1:2, 1:2)
 cellFromRowCol(r, 1, 1:3)
 
-# all combinations 
+# all combinations
 cellFromRowColCombine(r, 1:2, 1:2)
 
 colFromX(r, 10)
 rowFromY(r, 10)
 xy <- cbind(lon=c(10,5), lat=c(15, 88))
 cellFromXY(r, xy)
+
+# if no row/col specified all are returned
+range(xFromCol(r))
+length(yFromRow(r))
 }
 
 \keyword{spatial}


### PR DESCRIPTION
PR to add defaults for `row`, `col` args in `xFromCol`, `yFromRow`, see #583 