### PR TITLE
RcppModule: Fix typo

### DIFF
--- a/src/RcppModule.cpp
+++ b/src/RcppModule.cpp
@@ -3,7 +3,7 @@
 #include "spatRasterMultiple.h"
 #include <memory> //std::addressof
 #include "NA.h"
-#include "SpatTime.h"
+#include "spatTime.h"
 
 //static void SpatRaster_finalizer( SpatRaster* ptr ){
 //}


### PR DESCRIPTION
Fixes:
```c++
  RcppModule.cpp:6:10: fatal error: SpatTime.h: No such file or directory
      6 | #include "SpatTime.h"
```