### PR TITLE
project() for matrix input

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -4,7 +4,7 @@
 # License GPL v3
 
 
-setMethod("all.equal", signature(target="SpatRaster", current="SpatRaster"), 
+setMethod("all.equal", signature(target="SpatRaster", current="SpatRaster"),
 	function(target, current, maxcell=10000, ...) {
 		first <- all.equal.default(target, current)
 		if (isTRUE(first)) {
@@ -27,7 +27,7 @@ setMethod("all.equal", signature(target="SpatRaster", current="SpatRaster"),
 
 
 
-setMethod("weighted.mean", signature(x="SpatRaster", w="numeric"), 
+setMethod("weighted.mean", signature(x="SpatRaster", w="numeric"),
 	function(x, w, na.rm=FALSE, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$wmean_vect(w, na.rm, opt)
@@ -36,7 +36,7 @@ setMethod("weighted.mean", signature(x="SpatRaster", w="numeric"),
 )
 
 
-setMethod("weighted.mean", signature(x="SpatRaster", w="SpatRaster"), 
+setMethod("weighted.mean", signature(x="SpatRaster", w="SpatRaster"),
 	function(x, w, na.rm=FALSE, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <-x@ptr$wmean_rast(w@ptr, na.rm, opt)
@@ -46,7 +46,7 @@ setMethod("weighted.mean", signature(x="SpatRaster", w="SpatRaster"),
 
 
 
-setMethod("patches", signature(x="SpatRaster"), 
+setMethod("patches", signature(x="SpatRaster"),
 	function(x, directions=4, zeroAsNA=FALSE, allowGaps=TRUE, filename="", ...) {
 		if (allowGaps) {
 			opt <- spatOptions(filename, ...)
@@ -70,14 +70,14 @@ setMethod("patches", signature(x="SpatRaster"),
 )
 
 
-setMethod("origin", signature(x="SpatRaster"), 
+setMethod("origin", signature(x="SpatRaster"),
 	function(x) {
 		x@ptr$origin
 	}
 )
 
 
-setMethod("origin<-", signature("SpatRaster"), 
+setMethod("origin<-", signature("SpatRaster"),
 	function(x, value) {
 		value <- rep(value, length.out=2)
 		dif <- value - origin(x)
@@ -108,7 +108,7 @@ setMethod("origin<-", signature("SpatRaster"),
 
 
 
-setMethod("align", signature(x="SpatExtent", y="SpatRaster"), 
+setMethod("align", signature(x="SpatExtent", y="SpatRaster"),
 	function(x, y, snap="near") {
 		x@ptr <- y@ptr$align(x@ptr, tolower(snap))
 		#messages(x, "align")
@@ -116,14 +116,14 @@ setMethod("align", signature(x="SpatExtent", y="SpatRaster"),
 	}
 )
 
-setMethod("align", signature(x="SpatExtent", y="numeric"), 
+setMethod("align", signature(x="SpatExtent", y="numeric"),
 	function(x, y) {
 		x@ptr <- x@ptr$align(y, "")
 		x
 	}
 )
 
-setMethod("cellSize", signature(x="SpatRaster"), 
+setMethod("cellSize", signature(x="SpatRaster"),
 	function(x, mask=TRUE, unit="m", transform=TRUE, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$rst_area(mask, unit, transform, opt)
@@ -133,7 +133,7 @@ setMethod("cellSize", signature(x="SpatRaster"),
 
 
 
-setMethod ("expanse", "SpatRaster", 
+setMethod ("expanse", "SpatRaster",
 	function(x, unit="m", transform=TRUE) {
 
 		byvalue = FALSE
@@ -155,7 +155,7 @@ setMethod ("expanse", "SpatRaster",
 
 
 setMethod("atan2", signature(y="SpatRaster", x="SpatRaster"),
-	function(y, x) { 
+	function(y, x) {
 		opt <- spatOptions(filename="", overwrite=TRUE)
 		y@ptr <- y@ptr$atan2(x@ptr, opt)
 		messages(y, "atan2")
@@ -163,7 +163,7 @@ setMethod("atan2", signature(y="SpatRaster", x="SpatRaster"),
 )
 
 setMethod("atan_2", signature(y="SpatRaster", x="SpatRaster"),
-	function(y, x, filename="", ...) { 
+	function(y, x, filename="", ...) {
 		opt <- spatOptions(filename=filename, ...)
 		y@ptr <- y@ptr$atan2(x@ptr, opt)
 		messages(y, "atan_2")
@@ -171,7 +171,7 @@ setMethod("atan_2", signature(y="SpatRaster", x="SpatRaster"),
 )
 
 
-setMethod("boundaries", signature(x="SpatRaster"), 
+setMethod("boundaries", signature(x="SpatRaster"),
 	function(x, classes=FALSE, inner=TRUE, directions=8, falseval=0, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		type <- ifelse(inner[1], "inner", "outer")
@@ -186,16 +186,16 @@ setMethod("boundaries", signature(x="SpatRaster"),
 	messages(x, "tighten")
 }
 
-setMethod("deepcopy", signature("SpatRaster"), 
+setMethod("deepcopy", signature("SpatRaster"),
 	function(x) {
-		x@ptr <- x@ptr$deepcopy() 
+		x@ptr <- x@ptr$deepcopy()
 		x
 	}
 )
 
 
 
-setMethod("split", signature(x="SpatRaster"), 
+setMethod("split", signature(x="SpatRaster"),
 	function(x, f) {
 		stopifnot(length(f) == nlyr(x))
 		stopifnot(!any(is.na(f)))
@@ -205,10 +205,10 @@ setMethod("split", signature(x="SpatRaster"),
 )
 
 
-setMethod("add<-", signature("SpatRaster", "SpatRaster"), 
+setMethod("add<-", signature("SpatRaster", "SpatRaster"),
 	function(x, value) {
 		if (x@ptr$same(value@ptr)) {
-			x@ptr <- x@ptr$deepcopy() 
+			x@ptr <- x@ptr$deepcopy()
 		}
 		opt <- spatOptions()
 		x@ptr$addSource(value@ptr, FALSE, opt)
@@ -216,14 +216,14 @@ setMethod("add<-", signature("SpatRaster", "SpatRaster"),
 	}
 )
 
-setMethod("tighten", signature("SpatRaster"), 
+setMethod("tighten", signature("SpatRaster"),
 	function(x) {
 		x@ptr <- x@ptr$collapse_sources()
 		messages(x, "tighten")
 	}
 )
 
-setMethod("tighten", signature("SpatRasterDataset"), 
+setMethod("tighten", signature("SpatRasterDataset"),
 	function(x) {
 		y <- new("SpatRaster")
 		y@ptr <- x@ptr$collapse()
@@ -232,7 +232,7 @@ setMethod("tighten", signature("SpatRasterDataset"),
 )
 
 
-#setMethod("c", signature(x="SpatRaster"), 
+#setMethod("c", signature(x="SpatRaster"),
 #	function(x, ...) {
 #		s <- sds(list(x, ...))
 #		x@ptr <- s@ptr$collapse()
@@ -287,7 +287,7 @@ rbind.SpatVector <- function(x, y, ...) {
 }
 
 
-setMethod("c", signature(x="SpatRaster"), 
+setMethod("c", signature(x="SpatRaster"),
 	function(x, ..., warn=TRUE) {
 		skips <- 0
 		hv <- hasValues(x)
@@ -313,7 +313,7 @@ setMethod("c", signature(x="SpatRaster"),
 
 
 
-setMethod("rep", signature(x="SpatRaster"), 
+setMethod("rep", signature(x="SpatRaster"),
 	function(x, ...) {
 		i <- rep(1:nlyr(x), ...)
 		x[[i]]
@@ -321,7 +321,7 @@ setMethod("rep", signature(x="SpatRaster"),
 )
 
 
-setMethod("clamp", signature(x="SpatRaster"), 
+setMethod("clamp", signature(x="SpatRaster"),
 	function(x, lower=-Inf, upper=Inf, values=TRUE, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$clamp(lower, upper, values[1], opt)
@@ -330,7 +330,7 @@ setMethod("clamp", signature(x="SpatRaster"),
 )
 
 
-setMethod("clamp", signature(x="numeric"), 
+setMethod("clamp", signature(x="numeric"),
 function(x, lower=-Inf, upper=Inf, values=TRUE, ...) {
 	stopifnot(lower <= upper)
 	if (values) {
@@ -344,7 +344,7 @@ function(x, lower=-Inf, upper=Inf, values=TRUE, ...) {
 }
 )
 
-setMethod("classify", signature(x="SpatRaster"), 
+setMethod("classify", signature(x="SpatRaster"),
 function(x, rcl, include.lowest=FALSE, right=TRUE, others=NULL, brackets=TRUE, filename="", ...) {
 
 	bylayer = FALSE
@@ -361,7 +361,7 @@ function(x, rcl, include.lowest=FALSE, right=TRUE, others=NULL, brackets=TRUE, f
 		others <- FALSE
 		othersValue <- 0
 	} else {
-		othersValue <- others[1]	
+		othersValue <- others[1]
 		others <- TRUE
 	}
 	keepcats <- FALSE
@@ -381,13 +381,13 @@ function(x, rcl, include.lowest=FALSE, right=TRUE, others=NULL, brackets=TRUE, f
 		rcl <- cbind(rc1, rc2)[!is.na(rc1), ]
 		keepcats <- TRUE
 	}
-	
+
     x@ptr <- x@ptr$classify(as.vector(rcl), NCOL(rcl), right, include.lowest, others, othersValue, bylayer[1], brackets[1], keepcats, opt)
 	messages(x, "classify")
 }
 )
 
-setMethod("subst", signature(x="SpatRaster"), 
+setMethod("subst", signature(x="SpatRaster"),
 function(x, from, to, filename="", ...) {
 	opt <- spatOptions(filename, ...)
 
@@ -398,7 +398,7 @@ function(x, from, to, filename="", ...) {
 	if (inherits(to, "data.frame")) {
 		to <- as.matrix(to)
 	}
-	
+
 	keepcats <- FALSE
 	fromc <- inherits(from[1], "character")
 	toc <- inherits(to[1], "character")
@@ -423,9 +423,9 @@ function(x, from, to, filename="", ...) {
 		levs <- cats(x, 1, active=TRUE)[[1]]
 		from <- levs[,1][match(from, levs[,2])]
 		to <- levs[,1][match(to, levs[,2])]
-		keepcats <- TRUE		
+		keepcats <- TRUE
 	}
-	
+
 	if (inherits(to, "matrix")) {
 		opt$names = colnames(to)
 		x@ptr <- x@ptr$replaceValues(from, to, ncol(to), keepcats, opt)
@@ -440,9 +440,9 @@ function(x, from, to, filename="", ...) {
 .getExt <- function(y, method="crop") {
 	if (!inherits(y, "SpatExtent")) {
 		e <- try(ext(y), silent=TRUE)
-		if (class(e) == "try-error") { 
+		if (class(e) == "try-error") {
 			e <- try(ext(vect(y)), silent=TRUE)
-			if (class(e) == "try-error") { 
+			if (class(e) == "try-error") {
 				error(method, "cannot get a SpatExtent from y")
 			}
 		}
@@ -451,7 +451,7 @@ function(x, from, to, filename="", ...) {
 	y
 }
 
-setMethod("crop", signature(x="SpatRaster", y="ANY"), 
+setMethod("crop", signature(x="SpatRaster", y="ANY"),
 	function(x, y, snap="near", mask=FALSE, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		if (mask && inherits(y, "SpatVector")) {
@@ -464,7 +464,7 @@ setMethod("crop", signature(x="SpatRaster", y="ANY"),
 	}
 )
 
-setMethod("crop", signature(x="SpatRasterDataset", y="ANY"), 
+setMethod("crop", signature(x="SpatRasterDataset", y="ANY"),
 	function(x, y, snap="near", filename="", ...) {
 		if (all(filename != "")) {
 			ext <- tools::file_ext(filename)
@@ -480,15 +480,15 @@ setMethod("crop", signature(x="SpatRasterDataset", y="ANY"),
 
 
 
-setMethod("selectRange", signature(x="SpatRaster"), 
-	function(x, y, z=1, repint=0, filename="", ...) { 
+setMethod("selectRange", signature(x="SpatRaster"),
+	function(x, y, z=1, repint=0, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$selRange(y@ptr, z, repint, opt)
 		messages(x, "selectRange")
 	}
 )
 
-setMethod("cover", signature(x="SpatRaster", y="SpatRaster"), 
+setMethod("cover", signature(x="SpatRaster", y="SpatRaster"),
 	function(x, y, values=NA, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$cover(y@ptr, values, opt)
@@ -497,12 +497,12 @@ setMethod("cover", signature(x="SpatRaster", y="SpatRaster"),
 )
 
 
-setMethod("diff", signature(x="SpatRaster"), 
-	function(x, lag=1, filename="", ...) { 
+setMethod("diff", signature(x="SpatRaster"),
+	function(x, lag=1, filename="", ...) {
 		n <- nlyr(x)
 		lag <- round(lag)
 		if ((lag < 1) | (lag >= n)) {
-			error("diff", "lag must be > 0 and < nlyr(x)") 
+			error("diff", "lag must be > 0 and < nlyr(x)")
 		}
 		y <- x[[-((n-lag+1):n)]]
 		x <- x[[-(1:lag)]]
@@ -513,7 +513,7 @@ setMethod("diff", signature(x="SpatRaster"),
 )
 
 
-setMethod("disagg", signature(x="SpatRaster"), 
+setMethod("disagg", signature(x="SpatRaster"),
 	function(x, fact, method="near", filename="", ...) {
 		stopifnot(method %in% c("near", "bilinear"))
 		if (method == "bilinear") {
@@ -528,9 +528,9 @@ setMethod("disagg", signature(x="SpatRaster"),
 )
 
 
-setMethod("flip", signature(x="SpatRaster"), 
+setMethod("flip", signature(x="SpatRaster"),
 	function(x, direction="vertical", filename="", ...) {
-		d <- match.arg(direction, c("vertical", "horizontal")) 
+		d <- match.arg(direction, c("vertical", "horizontal"))
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$flip(d == "vertical", opt)
 		messages(x, "flip")
@@ -538,7 +538,7 @@ setMethod("flip", signature(x="SpatRaster"),
 )
 
 
-setMethod("freq", signature(x="SpatRaster"), 
+setMethod("freq", signature(x="SpatRaster"),
 	function(x, digits=0, value=NULL, bylayer=TRUE, usenames=FALSE) {
 
 		opt <- spatOptions()
@@ -591,7 +591,7 @@ setMethod("freq", signature(x="SpatRaster"),
 				v <- matrix(v[[1]], ncol=2, dimnames=list(NULL, c("value", "count")))
 			}
 			if (bylayer | (nlyr(x) == 1)) {
-				ff <- is.factor(x) 
+				ff <- is.factor(x)
 				if (any(ff)) {
 					cgs <- cats(x)
 					v <- data.frame(v)
@@ -619,16 +619,16 @@ setMethod("freq", signature(x="SpatRaster"),
 
 
 
-setMethod("mask", signature(x="SpatRaster", mask="SpatRaster"), 
-	function(x, mask, inverse=FALSE, maskvalues=NA, updatevalue=NA, filename="", ...) { 
+setMethod("mask", signature(x="SpatRaster", mask="SpatRaster"),
+	function(x, mask, inverse=FALSE, maskvalues=NA, updatevalue=NA, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$mask_raster(mask@ptr, inverse[1], maskvalues, updatevalue[1], opt)
 		messages(x, "mask")
 	}
 )
 
-setMethod("mask", signature(x="SpatRaster", mask="SpatVector"), 
-	function(x, mask, inverse=FALSE, updatevalue=NA, touches=TRUE, filename="", ...) { 
+setMethod("mask", signature(x="SpatRaster", mask="SpatVector"),
+	function(x, mask, inverse=FALSE, updatevalue=NA, touches=TRUE, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$mask_vector(mask@ptr, inverse[1], updatevalue[1], touches[1], opt)
 		messages(x, "mask")
@@ -636,9 +636,9 @@ setMethod("mask", signature(x="SpatRaster", mask="SpatVector"),
 )
 
 
-setMethod("project", signature(x="SpatRaster"), 
+setMethod("project", signature(x="SpatRaster"),
 	function(x, y, method, mask=FALSE, align=FALSE, gdal=TRUE, res=NULL, origin=NULL, filename="", ...)  {
-	  
+
 		if (missing(method)) {
 			if (is.factor(x)[1] || isTRUE(x@ptr$rgb)) {
 				method <- "near"
@@ -653,7 +653,7 @@ setMethod("project", signature(x="SpatRaster"),
 			warn("project", "argument 'method=ngb' is deprecated, it should be 'method=near'")
 		}
 		opt <- spatOptions(filename, ...)
-		
+
 		if (inherits(y, "SpatRaster")) {
 			if (gdal) {
 				x@ptr <- x@ptr$warp(y@ptr, "", method, mask[1], align[1], opt)
@@ -661,7 +661,7 @@ setMethod("project", signature(x="SpatRaster"),
 				if (align) {
 					y <- project(rast(x), y, align=TRUE)
 				}
-				x@ptr <- x@ptr$resample(y@ptr, method, mask[1], TRUE, opt)			
+				x@ptr <- x@ptr$resample(y@ptr, method, mask[1], TRUE, opt)
 			}
 		} else {
 			if (!is.character(y)) {
@@ -678,7 +678,7 @@ setMethod("project", signature(x="SpatRaster"),
 				x@ptr <- x@ptr$warp(SpatRaster$new(), y, method, mask, FALSE, opt)
 			} else {
 				y <- project(rast(x), y)
-				x@ptr <- x@ptr$resample(y@ptr, method, mask[1], TRUE, opt)				
+				x@ptr <- x@ptr$resample(y@ptr, method, mask[1], TRUE, opt)
 			}
 		}
 		messages(x, "project")
@@ -686,7 +686,7 @@ setMethod("project", signature(x="SpatRaster"),
 )
 
 
-setMethod("project", signature(x="SpatVector"), 
+setMethod("project", signature(x="SpatVector"),
 	function(x, y)  {
 		if (!is.character(y)) {
 			y <- crs(y)
@@ -696,9 +696,22 @@ setMethod("project", signature(x="SpatVector"),
 	}
 )
 
+setMethod("project", signature(x="matrix"),
+          function(x, y, source = NULL)  {
+            if (is.null(source)) stop("'source' projection must be provided for 'project(matrix, ...)'")
+            if (!is.character(y)) {
+              y <- crs(y)
+            }
+            xv <- vect(x, crs = source)
+            xv@ptr <- xv@ptr$project(y)
+            messages(xv, "project")
+            geom(xv)[ , c("x", "y"), drop = FALSE]
+          }
+)
 
-setMethod("quantile", signature(x="SpatRaster"), 
-	function(x, probs=seq(0, 1, 0.25), na.rm=FALSE, filename="", ...) { 
+
+setMethod("quantile", signature(x="SpatRaster"),
+	function(x, probs=seq(0, 1, 0.25), na.rm=FALSE, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$quantile(probs, na.rm[1], opt)
 		messages(x, "quantile")
@@ -706,8 +719,8 @@ setMethod("quantile", signature(x="SpatRaster"),
 )
 
 
-setMethod("quantile", signature(x="SpatVector"), 
-	function(x, probs=seq(0, 1, 0.25), ...) { 
+setMethod("quantile", signature(x="SpatVector"),
+	function(x, probs=seq(0, 1, 0.25), ...) {
 		x <- values(x)
 		cls <- sapply(x, class)
 		i <- cls != "character"
@@ -718,7 +731,7 @@ setMethod("quantile", signature(x="SpatVector"),
 )
 
 
-setMethod("rectify", signature(x="SpatRaster"), 
+setMethod("rectify", signature(x="SpatRaster"),
 	function(x, method="bilinear", aoi=NULL, snap=TRUE, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		if (!is.null(aoi)) {
@@ -741,9 +754,9 @@ setMethod("rectify", signature(x="SpatRaster"),
 	}
 )
 
-setMethod("resample", signature(x="SpatRaster", y="SpatRaster"), 
+setMethod("resample", signature(x="SpatRaster", y="SpatRaster"),
 	function(x, y, method, filename="", ...)  {
-	
+
 		if (missing(method)) {
 			method <- ifelse(is.factor(x)[1], "near", "bilinear")
 		}
@@ -755,7 +768,7 @@ setMethod("resample", signature(x="SpatRaster", y="SpatRaster"),
 #		if (gdal) {
 			x@ptr <- x@ptr$warp(y@ptr, "", method, FALSE, FALSE, opt)
 #		} else {
-#			x@ptr <- x@ptr$resample(y@ptr, method, FALSE, TRUE, opt)		
+#			x@ptr <- x@ptr$resample(y@ptr, method, FALSE, TRUE, opt)
 #		}
 		messages(x, "resample")
 	}
@@ -763,7 +776,7 @@ setMethod("resample", signature(x="SpatRaster", y="SpatRaster"),
 
 
 
-setMethod("impose", signature(x="SpatRasterCollection"), 
+setMethod("impose", signature(x="SpatRasterCollection"),
 	function(x, y, filename="", ...)  {
 		stopifnot(inherits(y, "SpatRaster"))
 		opt <- spatOptions(filename, ...)
@@ -775,16 +788,16 @@ setMethod("impose", signature(x="SpatRasterCollection"),
 
 
 
-setMethod("rev", signature(x="SpatRaster"), 
-	function(x) { 
+setMethod("rev", signature(x="SpatRaster"),
+	function(x) {
 		opt <- spatOptions("", FALSE, list())
 		x@ptr <- x@ptr$reverse(opt)
 		messages(x, "rev")
 	}
 )
 
-setMethod("rotate", signature(x="SpatRaster"), 
-	function(x, left=TRUE, filename="", ...) { 
+setMethod("rotate", signature(x="SpatRaster"),
+	function(x, left=TRUE, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$rotate(left, opt)
 		messages(x, "rotate")
@@ -792,7 +805,7 @@ setMethod("rotate", signature(x="SpatRaster"),
 )
 
 
-setMethod("segregate", signature(x="SpatRaster"), 
+setMethod("segregate", signature(x="SpatRaster"),
 	function(x, classes=NULL, keep=FALSE, other=0, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		if (is.null(classes)) classes <- 1[0]
@@ -802,8 +815,8 @@ setMethod("segregate", signature(x="SpatRaster"),
 )
 
 
-setMethod("shift", signature(x="SpatRaster"), 
-	function(x, dx=0, dy=0, filename="", ...) { 
+setMethod("shift", signature(x="SpatRaster"),
+	function(x, dx=0, dy=0, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$shift(dx, dy, opt)
 		messages(x, "shift")
@@ -811,23 +824,23 @@ setMethod("shift", signature(x="SpatRaster"),
 )
 
 
-setMethod("shift", signature(x="SpatExtent"), 
-	function(x, dx=0, dy=0) { 
+setMethod("shift", signature(x="SpatExtent"),
+	function(x, dx=0, dy=0) {
 		s <- c(dx[1], dx[1], dy[1], dy[1])
 		ext(as.vector(x) + s)
 	}
 )
 
 
-setMethod("shift", signature(x="SpatVector"), 
-	function(x, dx=0, dy=0) { 
+setMethod("shift", signature(x="SpatVector"),
+	function(x, dx=0, dy=0) {
 		x@ptr <- x@ptr$shift(dx, dy)
 		messages(x, "shift")
 	}
 )
 
-setMethod("rescale", signature(x="SpatRaster"), 
-	function(x, fx=0.5, fy=fx, x0, y0) { 
+setMethod("rescale", signature(x="SpatRaster"),
+	function(x, fx=0.5, fy=fx, x0, y0) {
 		stopifnot(fx > 0)
 		stopifnot(fy > 0)
 		e <- as.vector(ext(x))
@@ -845,8 +858,8 @@ setMethod("rescale", signature(x="SpatRaster"),
 	}
 )
 
-setMethod("rescale", signature(x="SpatVector"), 
-	function(x, fx=0.5, fy=fx, x0, y0) { 
+setMethod("rescale", signature(x="SpatVector"),
+	function(x, fx=0.5, fy=fx, x0, y0) {
 		stopifnot(fx > 0)
 		stopifnot(fy > 0)
 		e <- as.vector(ext(x))
@@ -862,8 +875,8 @@ setMethod("rescale", signature(x="SpatVector"),
 )
 
 
-setMethod("scale", signature(x="SpatRaster"), 
-	function(x, center=TRUE, scale=TRUE) { 
+setMethod("scale", signature(x="SpatRaster"),
+	function(x, center=TRUE, scale=TRUE) {
 
 		opt <- spatOptions()
 
@@ -886,7 +899,7 @@ setMethod("scale", signature(x="SpatRaster"),
 
 
 
-setMethod("stretch", signature(x="SpatRaster"), 
+setMethod("stretch", signature(x="SpatRaster"),
 	function(x, minv=0, maxv=255, minq=0, maxq=1, smin=NA, smax=NA, histeq=FALSE, scale=1, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		if (histeq) {
@@ -904,7 +917,7 @@ setMethod("stretch", signature(x="SpatRaster"),
 
 
 
-setMethod("summary", signature(object="SpatRaster"), 
+setMethod("summary", signature(object="SpatRaster"),
 	function(object, size=100000, warn=TRUE, ...)  {
 		if (!hasValues(object)) {
 			warn("summary", "SpatRaster has no values")
@@ -919,14 +932,14 @@ setMethod("summary", signature(object="SpatRaster"),
 )
 
 
-setMethod("summary", signature(object="SpatVector"), 
+setMethod("summary", signature(object="SpatVector"),
 	function(object, ...)  {
 		summary(as.data.frame(object), ...)
 	}
 )
 
 
-setMethod("t", signature(x="SpatRaster"), 
+setMethod("t", signature(x="SpatRaster"),
 	function(x) {
 		opt <- spatOptions()
 		x@ptr <- x@ptr$transpose(opt)
@@ -934,7 +947,7 @@ setMethod("t", signature(x="SpatRaster"),
 	}
 )
 
-setMethod("t", signature(x="SpatVector"), 
+setMethod("t", signature(x="SpatVector"),
 	function(x) {
 		x@ptr <- x@ptr$transpose()
 		messages(x, "t")
@@ -942,8 +955,8 @@ setMethod("t", signature(x="SpatVector"),
 )
 
 
-setMethod("terrain", signature(x="SpatRaster"), 
-	function(x, v="slope", neighbors=8, unit="degrees", filename="", ...) { 
+setMethod("terrain", signature(x="SpatRaster"),
+	function(x, v="slope", neighbors=8, unit="degrees", filename="", ...) {
 		unit <- match.arg(unit, c("degrees", "radians"))
 		opt <- spatOptions(filename, ...)
 		seed <- ifelse("flowdir" %in% v, .seed(), 0)
@@ -953,7 +966,7 @@ setMethod("terrain", signature(x="SpatRaster"),
 )
 
 
-setMethod("trim", signature(x="SpatRaster"), 
+setMethod("trim", signature(x="SpatRaster"),
 	function(x, padding=0, value=NA, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$trim(value[1], padding[1], opt)
@@ -961,7 +974,7 @@ setMethod("trim", signature(x="SpatRaster"),
 	}
 )
 
-setMethod("trans", signature(x="SpatRaster"), 
+setMethod("trans", signature(x="SpatRaster"),
 	function(x, filename="", ...) {
 		opt <- spatOptions(filename, ...)
 		x@ptr <- x@ptr$transpose(opt)
@@ -970,7 +983,7 @@ setMethod("trans", signature(x="SpatRaster"),
 )
 
 
-setMethod("unique", signature(x="SpatRaster", incomparables="ANY"), 
+setMethod("unique", signature(x="SpatRaster", incomparables="ANY"),
 	function(x, incomparables=FALSE, na.rm=FALSE) {
 		opt <- spatOptions()
 		u <- x@ptr$unique(incomparables, na.rm[1], opt)
@@ -998,7 +1011,7 @@ setMethod("unique", signature(x="SpatRaster", incomparables="ANY"),
 	}
 )
 
-setMethod("unique", signature(x="SpatVector", incomparables="ANY"), 
+setMethod("unique", signature(x="SpatVector", incomparables="ANY"),
 	function(x, incomparables=FALSE, ...) {
 		u <- unique(as.data.frame(x, geom="WKT"), incomparables=incomparables, ...)
 		v <- vect(u, geom="geometry")
@@ -1009,7 +1022,7 @@ setMethod("unique", signature(x="SpatVector", incomparables="ANY"),
 )
 
 
-#setMethod("warp", signature(x="SpatRaster", y="SpatRaster"), 
+#setMethod("warp", signature(x="SpatRaster", y="SpatRaster"),
 #	function(x, y, method="bilinear", filename="", overwrite=FALSE, ...)  {
 #		opt <- spatOptions(filename, overwrite, ...)
 #		x@ptr <- x@ptr$warp(y@ptr, "", method, opt)

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -3,35 +3,39 @@
 \alias{project}
 \alias{project,SpatVector-method}
 \alias{project,SpatRaster-method}
-
+\alias{project,matrix-method}
 \title{Change the coordinate reference system}
 
 \description{
-Change the coordinate reference system ("project") of a SpatVector or SpatRaster. 
+Change the coordinate reference system ("project") of a SpatVector or SpatRaster.
 }
 
 \usage{
 \S4method{project}{SpatVector}(x, y)
 
 \S4method{project}{SpatRaster}(x, y, method, mask=FALSE, align=FALSE, gdal=TRUE, res=NULL, origin=NULL, filename="", ...)
+
+\S4method{project}{matrix}(x, y, source)
 }
 
 \arguments{
-  \item{x}{SpatRaster or SpatVector}
-  \item{y}{if (\code{x} is a SpatRaster, the preferred approach is for \code{y} to be a SpatRaster as well, serving as a template for the geometry (extent and resolution) of the output SpatRaster. Alternatively, you can provide a coordinate reference system (CRS) description. 
-    
-  You can use the following formats to define coordinate reference systems: WKT,  PROJ.4 (e.g., \code{+proj=longlat +datum=WGS84}), or an EPSG code (e.g., \code{"epsg:4326"}). But note that the PROJ.4 notation has been deprecated, and you can only use if with the WGS84/NAD83 and NAD27 datums. Other datums are silently ignored. 
-  
+  \item{x}{SpatRaster or SpatVector, or matrix}
+  \item{y}{if (\code{x} is a SpatRaster, the preferred approach is for \code{y} to be a SpatRaster as well, serving as a template for the geometry (extent and resolution) of the output SpatRaster. Alternatively, you can provide a coordinate reference system (CRS) description.
+
+  You can use the following formats to define coordinate reference systems: WKT,  PROJ.4 (e.g., \code{+proj=longlat +datum=WGS84}), or an EPSG code (e.g., \code{"epsg:4326"}). But note that the PROJ.4 notation has been deprecated, and you can only use if with the WGS84/NAD83 and NAD27 datums. Other datums are silently ignored.
+
   If \code{x} is a SpatVector, you can provide a crs definition as discussed above, or any other object from which such a crs can be extracted with \code{\link{crs}}}
-  
-  \item{method}{character. Method used for estimating the new cell values of a SpatRaster. One of: 
-  
+
+  If \code{x} is a matrix, the same rules apply for the \code{y} and \code{source} arguments. In this case \code{source} is mandatory and must be provided.
+
+  \item{method}{character. Method used for estimating the new cell values of a SpatRaster. One of:
+
 	\code{near}: nearest neighbor. This method is fast, and it can be the preferred method if the cell values represent classes. It is not a good choice for continuous values. This is used by default if the first layer of \code{x} is categorical.
 
 	\code{bilinear}: bilinear interpolation. This is the default if the first layer of \code{x} is numeric (not categorical).
-	
+
 	\code{cubic}: cubic interpolation.
-	
+
 	\code{cubicspline}: cubic spline interpolation.
   }
 
@@ -43,9 +47,10 @@ Change the coordinate reference system ("project") of a SpatVector or SpatRaster
   \item{res}{numeric. Can be used to set the resolution of the output raster if \code{y} is a CRS}
 
   \item{origin}{numeric. Can be used to set the origon of the output raster if \code{y} is a CRS}
-  
+
   \item{filename}{character. Output filename}
-  
+
+  \item{source}{character, or object from which crs can be obtained}{The crs of of the input coordinates.}
   \item{...}{additional arguments for writing files as in \code{\link{writeRaster}}}
 }
 
@@ -57,13 +62,13 @@ SpatVector or SpatRaster
 \seealso{\code{\link{crs}}, \code{\link{resample}}}
 
 \note{
-User beware. Sadly, the PROJ.4 notation has been partly deprecated in the GDAL/PROJ library that is used by this function. You can still use this notation, but *only* with the the WGS84 datum. Other datums are silently ignored. 
+User beware. Sadly, the PROJ.4 notation has been partly deprecated in the GDAL/PROJ library that is used by this function. You can still use this notation, but *only* with the the WGS84 datum. Other datums are silently ignored.
 
 When printing a Spat* object the PROJ.4 notation is shown because it is the most concise and clear format available. However, internally a WKT representation is used (see \code{\link{crs}}).
 
-Transforming (projecting) raster data is fundamentally different from transforming vector data. Vector data can be transformed and back-transformed without loss in precision and without changes in the values. This is not the case with raster data. In each transformation the values for the new cells are estimated in some fashion. Therefore, if you need to match raster and vector data for analysis, you should generally transform the vector data. 
+Transforming (projecting) raster data is fundamentally different from transforming vector data. Vector data can be transformed and back-transformed without loss in precision and without changes in the values. This is not the case with raster data. In each transformation the values for the new cells are estimated in some fashion. Therefore, if you need to match raster and vector data for analysis, you should generally transform the vector data.
 
-When using this method with a \code{SpatRaster}, the preferable approach is to provide a template \code{SpatRaster} as argument \code{y}. The template is then another raster dataset that you want your data to align with. If you do not have a template to begin with, you can do \code{project(x, crs)} and then manipulate the output to get the template you want. For example, where possible use whole numbers for the extent and resolution so that you do not have to worry about small differences in the future. You can use commands like \code{dim(z) = c(180, 360)} or \code{res(z) <- 100000}. 
+When using this method with a \code{SpatRaster}, the preferable approach is to provide a template \code{SpatRaster} as argument \code{y}. The template is then another raster dataset that you want your data to align with. If you do not have a template to begin with, you can do \code{project(x, crs)} and then manipulate the output to get the template you want. For example, where possible use whole numbers for the extent and resolution so that you do not have to worry about small differences in the future. You can use commands like \code{dim(z) = c(180, 360)} or \code{res(z) <- 100000}.
 
 The output resolution should be similar to the input resolution, but there is not "correct" resolution in raster transformation; but it is not obvious what this resolution is if you are using lon/lat data that spans a large North-South extent.
 }
@@ -71,7 +76,7 @@ The output resolution should be similar to the input resolution, but there is no
 
 \examples{
 ## SpatRaster
-a <- rast(ncols=40, nrows=40, xmin=-110, xmax=-90, ymin=40, ymax=60, 
+a <- rast(ncols=40, nrows=40, xmin=-110, xmax=-90, ymin=40, ymax=60,
           crs="+proj=longlat +datum=WGS84")
 values(a) <- 1:ncell(a)
 newcrs="+proj=lcc +lat_1=48 +lat_2=33 +lon_0=-100 +datum=WGS84"
@@ -85,7 +90,12 @@ v <- vect(f)
 crs <- "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84"
 p <- project(v, crs)
 p
-}
 
+
+## matrix, note we must provide 'source', this is lon,lat order on WGS84
+lonlat <- cbind(c(0, 147), c(0, -42))
+project(lonlat, "+proj=laea +lon_0=147 +lat_0=-42 +datum=WGS84",
+  source = "OGC:CRS84")
+}
 \keyword{spatial}
 


### PR DESCRIPTION
Proposal for add 'matrix' method to `project()`.

This necessarily requires a 'source' arg to declare the crs of the 'x' input. 

This is not as fast as `rgdal::project()`, but nice to have that simple backwards-compatibility with the rgdal+raster idioms.  (I'm not concerned about the speed, this is likely to be addressed by [#413: rework of vect points](https://github.com/rspatial/terra/issues/413#issuecomment-991973367) previously discussed)


``` r
library(terra)
#> terra 1.5.29
    x <- geosphere::randomCoordinates(5e5)
    LAEA <- "+proj=laea +datum=WGS84"
    system.time(tp <- project(x, LAEA, source = "OGC:CRS84"))
#>    user  system elapsed 
#>   2.532   0.508   3.040
    system.time(rp <- rgdal::project(x, LAEA, inv = FALSE)); range(abs(tp - rp))
#>    user  system elapsed 
#>   0.441   0.004   0.445
#> [1] 0 0
```
