### PR TITLE
COG needs to be specified as filetype.

### DIFF
--- a/man/writeRaster.Rd
+++ b/man/writeRaster.Rd
@@ -78,11 +78,11 @@ f <- file.path(tempdir(), "test.tif")
 
 writeRaster(r, f, overwrite=TRUE)
 
-writeRaster(r, f, overwrite=TRUE, gdal=c("COMPRESS=NONE", "TFW=YES","of=COG"), datatype='INT1U')
+writeRaster(r, f, overwrite=TRUE, filetype="COG", gdal=c("COMPRESS=NONE", "TFW=YES"), datatype='INT1U')
 
 ## Or with a wopt argument:
 
-writeRaster(r, f, overwrite=TRUE, wopt= list(gdal=c("COMPRESS=NONE", "of=COG"), datatype='INT1U'))
+writeRaster(r, f, overwrite=TRUE, filetype="COG", wopt= list(gdal=c("COMPRESS=NONE"), datatype='INT1U'))
 
 ## remove the file
 unlink(f)


### PR DESCRIPTION
As originally written with `of` in the creation options, it is ignored as does write a valid cloud optimized geotiff. This is for #665 