### PR TITLE
Add <iterator> include

### DIFF
--- a/src/vecmath.h
+++ b/src/vecmath.h
@@ -19,6 +19,7 @@
 #define VECMATH_GUARD
 
 #include <functional>
+#include <iterator>
 #include <string>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
std::back_inserter comes from this header and is used on L106:

https://en.cppreference.com/w/cpp/iterator/back_insert_iterator