### PR TITLE
More informative error message for insufficient disk: indicate required and available space

### DIFF
--- a/src/write_gdal.cpp
+++ b/src/write_gdal.cpp
@@ -416,7 +416,7 @@ bool SpatRaster::writeStartGDAL(SpatOptions &opt) {
 	std::string dname = dirname(filename);
 	GIntBig diskAvailable = VSIGetDiskFreeSpace(dname.c_str());
 	if ((diskAvailable > -1) && (diskAvailable < diskNeeded)) {
-		setError("insufficient disk space (perhaps from temporary files?)");
+		setError("insufficient disk space. Need: " + std::to_string(diskNeeded/1073741824) + " GB. Available: " + std::to_string(diskAvailable/1073741824) + " GB.");
 		return(false);
 	}
 


### PR DESCRIPTION
Hi Robert

It would be great to have a more verbose message for insufficient space. Now the error message would look like:

> Error: [merge] insufficient disk space. Need: 71 GB. Available: 41 GB.

I have very little knowledge of cpp, so please check carefully. In particular, I am not sure about the digits printed out by `std::to_string`? Here it seems there is some rounding occurring? So I am not sure how the output looks like when the disk <1GB, though this seems a very unexpected case. 