### PR TITLE
fix for bilinearInt NaN handling

### DIFF
--- a/inst/tinytest/test_extract.R
+++ b/inst/tinytest/test_extract.R
@@ -67,3 +67,105 @@ expect_equal(round(as.vector(as.matrix(test)),5), c(1,2, 51.80006, 52.21312))
 test <- terra::extract(rr, p, fun = mean, exact=TRUE)
 expect_equal(round(as.vector(as.matrix(test)),5), c(1,2, 51.80006, 52.21312, 103.60012, 104.42623))
 
+
+
+r <- terra::rast(nrow = 2, ncol = 2, nlyrs = 1, xmin = -100, xmax = 100, ymin = -100, ymax = 100)
+terra::values(r) <- c(100, 100, NaN, 100)
+
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+
+
+r <- terra::rast(nrow = 2, ncol = 2, nlyrs = 1, xmin = -100, xmax = 100, ymin = -100, ymax = 100)
+terra::values(r) <- c(100, NaN, 100, 100)
+
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+
+
+r <- terra::rast(nrow = 2, ncol = 2, nlyrs = 1, xmin = -100, xmax = 100, ymin = -100, ymax = 100)
+terra::values(r) <- c(100, 100, 100, NaN)
+
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+
+
+r <- terra::rast(nrow = 2, ncol = 2, nlyrs = 1, xmin = -100, xmax = 100, ymin = -100, ymax = 100)
+terra::values(r) <- c(NaN, 100, 100, 100)
+
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+
+r <- terra::rast(nrow = 2, ncol = 2, nlyrs = 1, xmin = -100, xmax = 100, ymin = -100, ymax = 100)
+terra::values(r) <- c(NaN, NaN, 100, 100)
+
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+
+r <- terra::rast(nrow = 2, ncol = 2, nlyrs = 1, xmin = -100, xmax = 100, ymin = -100, ymax = 100)
+terra::values(r) <- c(NaN, 100, NaN, 100)
+
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+
+r <- terra::rast(nrow = 2, ncol = 2, nlyrs = 1, xmin = -100, xmax = 100, ymin = -100, ymax = 100)
+terra::values(r) <- c(NaN, 100, 100, NaN)
+
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+
+r <- terra::rast(nrow = 2, ncol = 2, nlyrs = 1, xmin = -100, xmax = 100, ymin = -100, ymax = 100)
+terra::values(r) <- c(100, NaN, NaN, 100)
+
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+
+r <- terra::rast(nrow = 2, ncol = 2, nlyrs = 1, xmin = -100, xmax = 100, ymin = -100, ymax = 100)
+terra::values(r) <- c(100, NaN, 100, NaN)
+
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+
+
+r <- terra::rast(nrow = 2, ncol = 2, nlyrs = 1, xmin = -100, xmax = 100, ymin = -100, ymax = 100)
+terra::values(r) <- c(100, 100, NaN, NaN)
+
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 0.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = 45.0, Y = -45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))
+expect_equal(terra::extract(r, data.frame(X = -45.0, Y = 45.0), method = "bilinear")$lyr.1 |> round(), c(100.0))


### PR DESCRIPTION
Hey guys,
I've picked up an error in the handling of NaNs in the bilinearInt method for the extract method. 
See the example below:
```
r <- terra::rast(nrow = 2, ncol = 2, nlyrs = 1, xmin = -100, xmax = 100, ymin = -100, ymax = 100)
terra::values(r) <- c(100, 100, NaN, 100)
print(terra::extract(r, data.frame(X = 45.0, Y = 45.0), method = "bilinear")$lyr.1)
# ought to be 100 but the value will be 55
```
Here the expected bilinear interpolation between points all with value 100 should always stay at 100 but we dip down to 55, 145. A quick peek at the source code shows that the handling isn't linearly adjusting when a NaN is found and simply using the value 0.5 which can lead to problems say when (y - y2) happens to be very small or very large; see below

https://github.com/rspatial/terra/blob/1820db49ed7173bb94656b38f2614dfb640f2f10/src/extract.cpp#L168-L183

I've implemented in the first commit a few tests which fail on the current version of extract with method = "bilinear" and then in the second commit I've added the linear/bilinear factor back in to fix this issue. All tests pass and personally I've been using this algorithm on rasters at work with good results. 