### PR TITLE
typo: when list = FALSE, extract returns a data.frame, not a matrix

### DIFF
--- a/man/extract.Rd
+++ b/man/extract.Rd
@@ -53,7 +53,7 @@ When argument \code{y} is a \code{SpatVector}, and \code{list=FALSE}, the first 
 \item{fun}{function to summarize the data by geometry. If \code{weights=TRUE} or \code{exact=TRUE} only \code{mean}, \code{sum}, \code{min} and \code{max} are accepted)}
 \item{...}{additional arguments to \code{fun} if \code{y} is a SpatVector. For example \code{na.rm=TRUE}. Or arguments passed to the \code{SpatRaster,SpatVector} method if \code{y} is a matrix (such as the \code{method} and \code{cells} arguments)}
 \item{method}{character. method for extracting values with points ("simple" or "bilinear"). With "simple" values for the cell a point falls in are returned. With "bilinear" the returned values are interpolated from the values of the four nearest raster cells}
-\item{list}{logical. If \code{FALSE} the output is simplified to a \code{matrix} (if \code{fun=NULL})}
+\item{list}{logical. If \code{FALSE} the output is simplified to a \code{data.frame} (if \code{fun=NULL})}
 \item{factors}{logical. If \code{TRUE} the categories are returned as factors instead of their numerical representation. The value returned becomes a data.frame if it otherwise would have been a matrix, even if there are no factors}
 \item{cells}{logical. If \code{TRUE} the cell numbers are also returned, unless \code{fun} is not \code{NULL}. Also see \code{\link{cells}}}
 \item{xy}{logical. If \code{TRUE} the coordinates of the cells are also returned, unless \code{fun} is not \code{NULL}. Also see \code{\link{xyFromCell}}}


### PR DESCRIPTION
In fact, are matrix ever returned by `extract`? If not, the Value field should also be updated to reflect that it only returns a `list` or a `data.frame`.