### PR TITLE
improve `vrt()` doc

### DIFF
--- a/man/vrt.Rd
+++ b/man/vrt.Rd
@@ -19,7 +19,7 @@ Create a Virtual Raster Tiles (VRT) dataset from a collection of file-based rast
 \arguments{
   \item{x}{character. Filenames of raster "tiles". See \code{\link{tiles}}}
   \item{filename}{character. Output VRT filename}  
-  \item{options}{character. Options as for \href{https://gdal.org/programs/gdalbuildvrt.html}{gdalbuildvrt}}
+  \item{options}{character. All arguments as separate vector elements. Options as for \href{https://gdal.org/programs/gdalbuildvrt.html}{gdalbuildvrt}}
   \item{overwrite}{logical. Should \code{filename} be overwritten if it exists?}
 }
 
@@ -40,7 +40,8 @@ ff <- makeTiles(r, x, filename)
 ff
 
 vrtfile <- paste0(tempfile(), ".vrt")
-v <- vrt(ff, vrtfile)
+# output in lower resolution
+v <- vrt(ff, vrtfile, options = c("-tr", 5, 5))
 head(readLines(vrtfile))
 v
 }


### PR DESCRIPTION
Improves documentation for #747.

I also wonder if the expansion of the VRT acronym as Virtual Raster Tiles is correct. The GDAL documentation uses Virtual Dataset (https://gdal.org/programs/gdalbuildvrt.html).