### PR TITLE
fix save path in `wrap()`

### DIFF
--- a/R/pack.R
+++ b/R/pack.R
@@ -136,7 +136,7 @@ setMethod("wrap", signature(x="SpatRaster"),
 			r@attributes$sources <- sources(x, TRUE, TRUE)
 		} else {
 			fname <- paste0(tempfile(), ".tif")
-			x <- writeRaster(x, tmpfile)
+			x <- writeRaster(x, fname)
 			r@attributes$filename <- fname
 		}
 		


### PR DESCRIPTION
BTW: `paste0(tempfile(), ".tif")` can be `tempfile(fileext = ".tif")`.