### PR TITLE
update pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -22,9 +22,7 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Install spatial dependencies
-        run: |
-          rm '/usr/local/bin/gfortran'
-          brew install gdal proj
+        run: brew install gdal proj
 
       - name: Query dependencies
         run: |


### PR DESCRIPTION
It seems that linking to `gfortran` works better in the new version of macOS, so we don't have to unnecessarily remove and reinstall it.