### PR TITLE
Makevars updates for Windows

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -19,7 +19,7 @@ clean:
 	rm -f $(SHLIB) $(OBJECTS)
 
 winlibs:
-	cp -r $(R_TOOLS_SOFT)/share/gdal ../inst/
-	cp -r $(R_TOOLS_SOFT)/share/proj ../inst/
+	cp -r "$(R_TOOLS_SOFT)/share/gdal" ../inst/
+	cp -r "$(R_TOOLS_SOFT)/share/proj" ../inst/
 
 .PHONY: all winlibs clean

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -25,8 +25,8 @@ all: clean winlibs
 winlibs:
 	mkdir -p ../inst
 	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" --vanilla "../tools/winlibs.R" $(VERSION)
-	cp -r $(RWINLIB)/share/gdal ../inst/
-	cp -r $(RWINLIB)/share/proj ../inst/
+	cp -r "$(RWINLIB)/share/gdal" ../inst/
+	cp -r "$(RWINLIB)/share/proj" ../inst/
 
 clean:
 	rm -f $(SHLIB) $(OBJECTS)


### PR DESCRIPTION
When building terra from source on my work (Windows) machine (which has Rtools42 installed in "C:/Program Files/rtools42/") I get the following error. 

```
cp -r C:/Program Files/rtools42/x86_64-w64-mingw32.static.posix/share/gdal ../inst/
cp: cannot stat 'C:/Program': No such file or directory
cp: cannot stat 'Files/rtools42/x86_64-w64-mingw32.static.posix/share/gdal': No such file or directory
make: *** [Makevars.ucrt:22: winlibs] Error 1
ERROR: compilation failed for package 'terra'
```

This appears to be because the path `$R_TOOLS_SOFT` has spaces in the name and is not quoted. Since this is my work computer I unfortunately have no control over where Rtools is installed. Adding quotes around the relevant path in Makevars.ucrt fixes the issue for me.

I assume this also could affect `$(RWINLIB)/share/gdal` paths used for older R versions, so I made an analogous change in Makevars.win.