### PR TITLE
Mention `zonal()` in `extract()` docs

### DIFF
--- a/man/extract.Rd
+++ b/man/extract.Rd
@@ -33,6 +33,8 @@
 Extract values from a SpatRaster for a set of locations. The locations can be a SpatVector (points, lines, polygons), a matrix with (x, y) or (longitude, latitude -- in that order!) coordinates, or a vector with cell numbers.  
 
 When argument \code{y} is a \code{SpatVector} the first column has the ID (record number) of the \code{SpatVector} used (unless you set \code{ID=FALSE}).
+
+Alternatively, you can use \code{\link{zonal}} after using \code{\link{rasterize}} on \code{SpatVector} (this may be more efficient in some cases).
 } 
 
 \usage{
@@ -68,7 +70,7 @@ When argument \code{y} is a \code{SpatVector} the first column has the ID (recor
 
 \value{data.frame, matrix or SpatVector}
 
-\seealso{\link{values}}
+\seealso{\link{values}, \link{zonal}}
 
 \examples{
 r <- rast(ncols=5, nrows=5, xmin=0, xmax=5, ymin=0, ymax=5)


### PR DESCRIPTION
I think it is worth mentioning `zonal()` in the `extract()` documentation as an alternative way, because `zonal()` may be more efficient in some cases. Here is simple example:

```r
f = system.file("ex/lux.shp", package = "terra")
v = vect(f)
n = 2000
r = rast(v, nrows = n, ncols = n, names = "value")
values(r) = rnorm(ncell(r))

system.time({
  x1 = extract(r, v, fun = "mean")
})
#> user  system elapsed
#> 8.34    0.47    8.84

system.time({
  rr = rasterize(v, r, field = seq_len(nrow(v)))
  x2 = zonal(r, rr, "mean")
})
#> user  system elapsed
#> 0.25    0.14    0.39

all.equal(x1$value, x2$value)
#> TRUE
```