### PR TITLE
fix typo in split() #979

### DIFF
--- a/R/geom.R
+++ b/R/geom.R
@@ -107,7 +107,7 @@ as.list.svc <- function(x) {
 setMethod("split", signature(x="SpatVector"),
 	function(x, f) {
 		if (length(f) > 1) {
-			x <- copy(x)
+			x <- deepcopy(x)
 			x$f <- f
 			f <- "f"
 		}


### PR DESCRIPTION
Fix the problem reported in #979
seems that it was just a typo.