### PR TITLE
fix sampling a raster with two dimension

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -385,8 +385,14 @@ setMethod("spatSample", signature(x="SpatRaster"),
 		if (any(size < 1)) {
 			error("spatSample", "sample size must be a positive integer")
 		}
-		if ((size > ncell(x)) & (!replace)) {
-			size <- ncell(x)
+		if (!replace) {
+			if ( length(size) == 1 && (size > ncell(x))) {
+				warn("spatSample", "requested sample size is larger than the number of cells")
+				size <- ncell(x)
+			} else if (length(size) > 1 & any(size[1] > nrow(x), size[2] > ncol(x))) {
+				warn("spatSample", "requested sample dimensions are larger than the source raster")
+				size <- pmin(size, c(nrow(x), ncol(x)))
+			}
 		}
 
 		method <- match.arg(tolower(method), c("random", "regular", "stratified", "weights"))
@@ -483,8 +489,7 @@ setMethod("spatSample", signature(x="SpatRaster"),
 
 		method <- tolower(method)
 		stopifnot(method %in% c("random", "regular"))
-		if (!replace) size <- pmin(ncell(x), size)
-
+	
 		if (!is.null(ext)) x <- crop(x, ext)
 
 		if (method == "regular") {


### PR DESCRIPTION
possible fix for #991

Feel free to improve on it or fix it otherwise tho :)

````
library(terra)
f <- system.file("ex/elev.tif", package="terra")
r <- rast(f)
plot(r)

s <- spatSample(r, 100 , "regular", as.raster=TRUE)
plot(s)
# this works as expected

s2 <- spatSample(r, round(c(nrow(r)/2,ncol(r)/2)), "regular", as.raster=TRUE)
plot(s2)
# this works as expected

#####################

s <- spatSample(r, 1000000 , "regular", as.raster=TRUE)
plot(s)
# this throws a warning as expected

s2 <- spatSample(r, round(c(nrow(r)+1,ncol(r)+1)), "regular", as.raster=TRUE)
plot(s2)
# this throws a warning as expected
````