### PR TITLE
`crds(<SpatRaster>)`: use `as.points(..., values=FALSE)` to avoid warnings

### DIFF
--- a/R/spatvec.R
+++ b/R/spatvec.R
@@ -96,7 +96,7 @@ setMethod("crds", signature(x="SpatVector"),
 
 setMethod("crds", signature(x="SpatRaster"),
 	function(x, df=FALSE, na.rm=TRUE){
-		x <- as.points(x, na.rm=na.rm)
+		x <- as.points(x, values=FALSE, na.rm=na.rm)
 		crds(x, df=df)
 	}
 )


### PR DESCRIPTION
Hello Robert!

Warning `Warning: [as.points] raster has no values` is issued by `crds()` when used on a template (no values) SpatRaster.

With current development terra 1.7-33:
``` r
library(terra)
#> terra 1.7.33

r <- rast(matrix(rep(NaN, 9), ncol=3))

# no warning
crds(r, na.rm = FALSE) |> head(3)
#>        x   y
#> [1,] 0.5 2.5
#> [2,] 1.5 2.5
#> [3,] 2.5 2.5

# warning from as.points
crds(rast(r), na.rm = FALSE) |> head(3)
#> Warning: [as.points] raster has no values
#>        x   y
#> [1,] 0.5 2.5
#> [2,] 1.5 2.5
#> [3,] 2.5 2.5

# passing values=FALSE to as.points(): no warning (this should be crds() default)
as.points(rast(r), values = FALSE) |> crds() |> head(3)
#>        x   y
#> [1,] 0.5 2.5
#> [2,] 1.5 2.5
#> [3,] 2.5 2.5

# values returns the same thing (result and latter warning makes sense)
all.equal(values(r), values(rast(r)))
#> Warning: [readValues] raster has no values
#> [1] TRUE
```

I think that it makes sense to warn about missing values when values are requested (e.g. with `values()`), but in the case of `crds(<SpatRaster>)` probably `values=FALSE` could be used to avoid the warning as only coordinates are requested

This might be a bit nitpicky, and there may be a reason for this warning I am not aware of, but figured I would make this suggestion for your consideration. 