### PR TITLE
Added skip argument for makeTiles() command

### DIFF
--- a/R/tiles.R
+++ b/R/tiles.R
@@ -1,12 +1,12 @@
 
 setMethod("makeTiles", signature(x="SpatRaster"),
-	function(x, y, filename="tile_.tif", extend=FALSE, na.rm=FALSE, ...) {
+	function(x, y, filename="tile_.tif", extend=FALSE, na.rm=FALSE, skip=0, ...) {
 		filename <- trimws(filename[1])
 		filename <- filename[!is.na(filename)]
 		if (filename == "") error("makeTiles", "filename cannot be empty")
 		opt <- spatOptions(filename="", ...)
 		if (inherits(y, "SpatRaster")) {
-			ff <- x@pnt$make_tiles(y@pnt, extend[1], na.rm[1], filename, opt)
+			ff <- x@pnt$make_tiles(y@pnt, extend[1], na.rm[1], skip[1], filename, opt)
 		} else if (inherits(y, "SpatVector")) {
 			ff <- x@pnt$make_tiles_vect(y@pnt, extend[1], na.rm[1], filename, opt)		
 		} else if (is.numeric(y)) {
@@ -15,7 +15,7 @@ setMethod("makeTiles", signature(x="SpatRaster"),
 			}
 			y <- rep_len(y, 2)
 			y <- aggregate(rast(x), y)
-			ff <- x@pnt$make_tiles(y@pnt, extend[1], na.rm[1], filename, opt)			
+			ff <- x@pnt$make_tiles(y@pnt, extend[1], na.rm[1], skip[1], filename, opt)			
 		} else {
 			error("makeTiles", "y must be a SpatRaster or SpatVector")
 		}

--- a/src/raster_methods.cpp
+++ b/src/raster_methods.cpp
@@ -115,7 +115,7 @@ SpatExtent SpatRaster::ext_from_cell(double cell) {
 }
 
 
-std::vector<std::string> SpatRaster::make_tiles(SpatRaster x, bool expand, bool narm, std::string filename, SpatOptions &opt) {
+std::vector<std::string> SpatRaster::make_tiles(SpatRaster x, bool expand, bool narm, int skip, std::string filename, SpatOptions &opt) {
 
 	std::vector<std::string> ff;
 	if (!hasValues()) {
@@ -137,7 +137,7 @@ std::vector<std::string> SpatRaster::make_tiles(SpatRaster x, bool expand, bool 
 	std::string f = noext(filename);
 	ff.reserve(d.size());
 	size_t nl = nlyr();
-	for (size_t i=0; i<d.size(); i++) {
+	for (size_t i=skip; i<d.size(); i++) {
 		std::string fout = f + std::to_string(d[i]) + fext;
 		SpatExtent exi = x.ext_from_cell(i);
 		opt.set_filenames({fout});

--- a/src/spatRaster.h
+++ b/src/spatRaster.h
@@ -702,7 +702,7 @@ class SpatRaster {
 		SpatExtent ext_from_rc(int_64 r1, int_64 r2, int_64 c1, int_64 c2);
 		SpatExtent ext_from_cell(double cell);
 
-		std::vector<std::string> make_tiles(SpatRaster x, bool expand, bool narm, std::string filename, SpatOptions &opt);
+		std::vector<std::string> make_tiles(SpatRaster x, bool expand, bool narm, int skip, std::string filename, SpatOptions &opt);
 		std::vector<std::string> make_tiles_vect(SpatVector x, bool expand, bool narm, std::string filename, SpatOptions &opt);
 
 		SpatRaster mask(SpatRaster &x, bool inverse, double maskvalue, double updatevalue, SpatOptions &opt);


### PR DESCRIPTION
This pull request resolves #1167, allowing for users to skip a certain number of tiles when running the `makeTiles()` command using the `skip` keyword argument. 

I am not used to contributing like this and do not have a lot of experience with C++. If this needs additional polish or other work, please let me know and I will see what I can do!