### PR TITLE
Use full `function` keyword in `tiles.R`

### DIFF
--- a/R/SpatRasterDataset.R
+++ b/R/SpatRasterDataset.R
@@ -74,7 +74,7 @@ setMethod("sds", signature(x="list"),
 			} else if (inherits(x[[i]], "SpatRasterDataset")) {
 				y <- as.list(x[[i]])
 				ynms <- names(x[[i]])
-				s <- sapply(y, \(j) r@cpp$add(j@cpp, ynms[j], "", "", FALSE))
+				s <- sapply(y, function(j) r@cpp$add(j@cpp, ynms[j], "", "", FALSE))
 			} else {
 				name <- names(x[[i]])
 				cls <- paste(class(x[[i]]), collapse=", ")
@@ -301,7 +301,7 @@ setMethod("sprc", signature(x="list"),
 				} else if (inherits(x[[i]], "SpatRasterCollection") | 
 							inherits(x[[i]], "SpatRasterDataset")) {
 					y <- as.list(x[[i]])
-					s <- sapply(y, \(j) ptr$add(j@cpp, ""))
+					s <- sapply(y, function(j) ptr$add(j@cpp, ""))
 				} else {
 					name <- names(x[[i]])
 					cls <- paste(class(x[[i]]), collapse=", ")

--- a/R/tiles.R
+++ b/R/tiles.R
@@ -84,9 +84,9 @@ vrt_tiles <- function(x) {
 			v <- readLines(f)
 			v <- v[grep("SourceFilename", v)]
 			s <- strsplit(v, "\"")
-			rel <- sapply(s, \(x) x[2])
-			ff <- strsplit(sapply(s, \(x)x[3]), "<")
-			ff <- gsub(">", "", sapply(ff, \(x) x[1]))
+			rel <- sapply(s, function(x) x[2])
+			ff <- strsplit(sapply(s, function(x) x[3]), "<")
+			ff <- gsub(">", "", sapply(ff, function(x) x[1]))
 			ff[rel=="1"] <- file.path(dirname(f), ff[rel=="1"])
 			ff
 		})


### PR DESCRIPTION
A small PR to restore compatibility with older versions of R < 4.1 by using the `function` keyword rather than the newer inline anonymous function syntax.

I looked quickly for other uses of `\()` in `R/` and think I got them, but may have been mislead by GitHub code search