### PR TITLE
Use pkg-config on Windows when available.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,9 +1,13 @@
 TARGET = lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH)
 
-LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
 
-PKG_LIBS =  \
+  PKG_LIBS =  \
 -fopenmp -lgdal -larmadillo -lopenblas -lgfortran -lquadmath -lpq -lpgcommon -lpgport -lodbc32 -lodbccp32 -lblosc -lkea -lhdf5_cpp -lhdf5 -lpoppler -llcms2 -lfreetype -lharfbuzz -lfreetype -llz4 -lpcre2-8 -lxml2 -lopenjp2 -lnetcdf -lmysqlclient -lspatialite -lgeos_c -lgeos -lminizip -lgeos -ljson-c -lgta -lfreexl -lexpat -lssl -lpsapi -lgif -lmfhdf -lhdf5_hl -lcrypto -lportablexdr -ldf -lhdf5 -lsz -lpng16 -lpng -lpoppler -llcms2 -lfreetype -lharfbuzz -lfreetype -llz4 -lpcre2-8 -lpcre -lcurl -lbcrypt -lrtmp -lssl -lssh2 -lidn2 -lunistring -liconv -lgcrypt -lcrypto -lgpg-error -lws2_32 -ltiff -llzma -ljpeg -lz -lcfitsio -lzstd -lwebpdecoder -lwebp $(LIBSHARPYUV) -lsbml-static -lgeotiff -lproj -lsqlite3 -lbz2 -lcrypt32 -lwldap32 -lsecur32
+else
+  PKG_LIBS = $(shell pkg-config --libs gdal geos proj)
+endif
 
 CXX_STD = CXX
 


### PR DESCRIPTION
This will use pkg-config to establish the libraries to link when pkg-config is available (which will soon be in Rtools). This should reduce the frequency of needed updates to linking when new features are linked/enabled in gdal.