### PR TITLE
fix compilation failure on latest Alpine 3.19.0

### DIFF
--- a/src/spatDataframe.h
+++ b/src/spatDataframe.h
@@ -25,6 +25,7 @@
 #include "spatBase.h"
 #include "spatTime.h"
 #include "spatFactor.h"
+#include <cstdint>
 #include <limits>
 
 class SpatDataFrame {


### PR DESCRIPTION
**terra** fails to install on latest Alpine Linux 3.19.0:
```
In file included from spatVector.h:21,
                 from spatRaster.h:20,
                 from spatRasterMultiple.h:18,
                 from arith.cpp:19:
spatDataframe.h:51:41: error: 'int8_t' was not declared in this scope
   51 |                 std::vector<std::vector<int8_t>> bv;
      |                                         ^~~~~~
spatDataframe.h:28:1: note: 'int8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
```
I can confirm that this patch fixes installation on Alpine Linux.