### PR TITLE
update `plet()` documentation

### DIFF
--- a/man/plet.Rd
+++ b/man/plet.Rd
@@ -15,8 +15,6 @@
 
 \description{
 Plot the values of a SpatRaster or SpatVector to make an interactive leaflet map that is displayed in a browser.
-
-These methods require the development version of leaflet that you can install with \code{remotes::install_github("rstudio/leaflet")}.
 }
 
 \usage{


### PR DESCRIPTION
The current CRAN version of `leafet` now supports `SpatVector` and `SpatRaster`, so the text in `plet` stating that the development version is needed is no longer necessary. I made sure this was the case with the following code (I have the CRAN version of `leaflet`): 

```r
library(terra)
v <- vect(system.file("ex/lux.shp", package = "terra"))
r <- rast(system.file("ex/elev.tif", package = "terra"))
plet(v)
plet(svc(v))
plet(r)
```