### PR TITLE
add check for empty width in 'buffer'

### DIFF
--- a/R/geom.R
+++ b/R/geom.R
@@ -312,6 +312,9 @@ setMethod("buffer", signature(x="SpatVector"),
 		if (!is.numeric(width)) {
 			error("buffer", "width is not numeric")
 		}
+		if (length(width) == 0) {
+			error("buffer", "width is empty")
+		}
 		x@ptr <- x@ptr$buffer(width, quadsegs, tolower(capstyle), tolower(joinstyle), mitrelimit, singlesided)
 		messages(x, "buffer")
 	}


### PR DESCRIPTION
Using a zero-length width with `buffer()` was causing R to abort. For example:

```r
library(terra)
v <- vect(system.file("ex/lux.shp", package = "terra"))
buffer(v, numeric(0)) # causes R to abort
```

I added code to check if `width` has length 0.