### PR TITLE
Better representation for plet

### DIFF
--- a/R/plot_let.R
+++ b/R/plot_let.R
@@ -69,7 +69,7 @@ baselayers <- function(tiles, wrap=TRUE) {
 	
 	if (is.null(type)) type <- ""
 	if (type == "continuous") type <- "interval"	
-	if ((!is.numeric(v)) || (length(unique(v)) < 11)) {
+	if (!is.numeric(v)) {
 		type <- "classes"
 	} else if (type == "") {
 		type <- "interval"

--- a/R/plot_vector.R
+++ b/R/plot_vector.R
@@ -295,12 +295,16 @@ setMethod("dots", signature(x="SpatVector"),
 
 	cols <- out$cols
 	ncols <- length(cols)
-	if (nlevs < ncols) {
-		i <- trunc((ncols / nlevs) * 1:nlevs)
-		cols <- cols[i]
+
+	if (out$legend_type == "classes" && nlevs > ncols) {
+    # more classes than colors: cycle from beginning
+		cols_idx <- rep_len(cols, nlevs)
 	} else {
-		cols <- rep_len(cols, nlevs)
+    # else we interpolate the colors (better for continuous ramp)
+		cols_idx <- trunc(seq(1, ncols, length.out = nlevs))
 	}
+	cols <- cols[cols_idx]
+	
 	out$cols <- cols
 	out$leg$fill <- cols
 	out$legend_type <- "classes"


### PR DESCRIPTION
## plot_vector.R: improve color subsetting for continuous ramps
Use `seq` for interpolating the indices for continuous ramps, which makes more sense, specially if the number of colors is less than number of classes.

## plot_let.R: remove the 10 observations limit to type="classes"

The type of representation should not be limited to hardcoded values, unless it is unsafe for the code (which is not the case).

I think it is safe to assume that if the variable is numeric it is supposed to be represented as intervals or ramp, or else the user should be passing a `factor` or `integer` instead.