### PR TITLE
Autodetect drivers for SOZIP-enabled write of .shz, .shp.zip, .gpkg.zip files

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -70,11 +70,13 @@ function(x, filename="", overwrite=FALSE, ...) {
 )
 
 
-get_filetype <- function(filename) {
-	ext <- tolower(tools::file_ext(filename))
-	if (ext == "shp" || ext == "") {
+get_filetype <- function(filename) {  
+	fn <- tolower(filename)
+	ext <- tools::file_ext(fn)
+	ext2 <- gsub("^[^.]*\\.(.*).*$", "\\1", fn)
+	if (ext == "shp" || ext == "shz" || (ext == "zip" && ext2 == "shp.zip") || ext == "") {
 		"ESRI Shapefile"
-	} else if (ext == "gpkg") {
+	} else if (ext == "gpkg" || (ext == "zip" && ext2 == "gpkg.zip")) {
 		"GPKG"
 	} else if (ext == "gdb") {
 		"OpenFileGDB"


### PR DESCRIPTION
This PR makes it easier to write Seek-Optimized ZIP (SOZIP)-enabled Shapefile (.shz, .shp.zip extensions) and GeoPackage (.gpkg.zip extension) without manual specification of the `filetype` in `writeVector()`

This works with GDAL >= 3.7. 

``` r
library(terra)
#> terra 1.7.74

x <- vect(system.file('ex', 'lux.shp', package = "terra"))

writeVector(x, "test.shz")
file.size("test.shz")
#> [1] 33549

writeVector(x, "test.shp")
file.size("test.shp")
#> [1] 64692

writeVector(x, "test.shp.zip")
file.size("test.shp.zip")
#> [1] 33589

writeVector(x, "test.gpkg.zip")
file.size("test.gpkg.zip")
#> [1] 37926

writeVector(x, "test.gpkg")
file.size("test.gpkg")
#> [1] 172032
```

---

From https://gdal.org/user/virtual_file_systems.html#sozip-seek-optimized-zip
> [SOZip (Seek-Optimized ZIP)](https://gdal.org/user/virtual_file_systems.html#sozip-seek-optimized-zip) 
>
> GDAL (>= 3.7) has full read and write support for .zip files following the [SOZip (Seek-Optimized ZIP)](https://sozip.org/) profile.
>  - The /vsizip/ virtual file system uses the SOZip index to perform fast random access within a compressed SOZip-enabled file.
>  - The [ESRI Shapefile / DBF](https://gdal.org/drivers/vector/shapefile.html#vector-shapefile) and [GPKG -- GeoPackage vector](https://gdal.org/drivers/vector/gpkg.html#vector-gpkg) drivers can directly generate SOZip-enabled .shz/.shp.zip or .gpkg.zip files.
>
> ...