### PR TITLE
Robustly use osVersion

### DIFF
--- a/R/show.R
+++ b/R/show.R
@@ -5,7 +5,7 @@
 
 
 win_basename <- function(x) {
-	if (grepl("Windows", utils::osVersion)) {
+	if (isTRUE(grepl("Windows", utils::osVersion))) {
 		large <- nchar(x) > 256
 		if (any(large)) {
 			for (i in 1:length(large)) {


### PR DESCRIPTION
`osVersion` is documented to be `NULL` on some "bizarre systems" (including the one where we run our tests :) ).

On such systems, there will be widespread package issues because of issues resulting from assuming this `grepl()` will return `TRUE` or `FALSE` (instead of `logical()`).