### PR TITLE
GDAL VSI Files

### DIFF
--- a/src/file_utils.h
+++ b/src/file_utils.h
@@ -18,6 +18,7 @@
 #ifndef FILEUTILS_GUARD
 #define FILEUTILS_GUARD
 
+bool file_remove(const std::string& name);
 bool file_exists(const std::string& name);
 bool path_exists(std::string path);
 bool filepath_exists(const std::string& name);

--- a/src/write_gdal.cpp
+++ b/src/write_gdal.cpp
@@ -315,17 +315,15 @@ void stat_options(int sstat, bool &compute_stats, bool &gdal_stats, bool &gdal_m
 	}
 }
 
-
 void removeVatJson(std::string filename) {
 	std::vector<std::string> exts = {".vat.dbf", ".vat.cpg", ".json"};
 	for (size_t i=0; i<exts.size(); i++) {
 		std::string f = filename + exts[i];
 		if (file_exists(f)) {
-			remove(f.c_str());
+			file_remove(f);
 		}
 	}
 }
-
 
 bool SpatRaster::writeStartGDAL(SpatOptions &opt, const std::vector<std::string> &srcnames) {
 
@@ -397,9 +395,9 @@ bool SpatRaster::writeStartGDAL(SpatOptions &opt, const std::vector<std::string>
 
 // what if append=true?
 	std::string auxf = filename + ".aux.xml";
-	remove(auxf.c_str());
+	file_remove(auxf);
 	auxf = filename + ".aux.json";
-	remove(auxf.c_str());
+	file_remove(auxf);
 
 	std::vector<bool> hasCT = hasColors();
 	std::vector<bool> hasCats = hasCategories();


### PR DESCRIPTION
This is an attempt at using [GDAL VSIVirtualHandle API](https://gdal.org/en/stable/doxygen/cpl__vsi_8h.html) to read and write text files such as aux.json. With this PR the files are written and read from e.g. ZIP file via /vsizip/ if needed. Some more general file-related functions are updated in https://github.com/rspatial/terra/commit/ad96dc4b8c7d8e739d25a38fbfcdbbe8a3e23180.

Here is an example showing write and recovery of metadata for Zarr output written to a ZIP file with /vsizip/
``` r
library(terra)
#> terra 1.8.9

f <- system.file("ex/elev.tif", package="terra")
r <- rast(f)

x <- c(r, r*2, r*3)
time(x) <- rep(Sys.Date(), 3)
units(x) <- rep("m", 3)
x
#> class       : SpatRaster 
#> dimensions  : 90, 95, 3  (nrow, ncol, nlyr)
#> resolution  : 0.008333333, 0.008333333  (x, y)
#> extent      : 5.741667, 6.533333, 49.44167, 50.19167  (xmin, xmax, ymin, ymax)
#> coord. ref. : lon/lat WGS 84 (EPSG:4326) 
#> sources     : elev.tif  
#>               memory  
#>               memory  
#> varnames    : elev 
#>               elev 
#>               elev 
#> names       : elevation, elevation, elevation 
#> min values  :       141,       282,       423 
#> max values  :       547,      1094,      1641 
#> unit        :         m,         m,         m 
#> time (days) : 2025-01-05

dir.create("test/path", showWarnings = FALSE, recursive = TRUE)
writeRaster(x, "test/path/out0.zarr",   filetype = "Zarr")
#> Warning: SetRawNoDataValue() not implemented (GDAL error 6)
#> Warning: SetRawNoDataValue() not implemented (GDAL error 6)
#> Warning: SetRawNoDataValue() not implemented (GDAL error 6)
writeRaster(x, "/vsizip/test/path/out1.zip/out",    filetype = "Zarr")
#> Warning: SetRawNoDataValue() not implemented (GDAL error 6)
#> Warning: SetRawNoDataValue() not implemented (GDAL error 6)
#> Warning: SetRawNoDataValue() not implemented (GDAL error 6)
writeRaster(x, "/vsizip/{test/path/out2}/out",  filetype = "Zarr")
#> Warning: SetRawNoDataValue() not implemented (GDAL error 6)
#> Warning: SetRawNoDataValue() not implemented (GDAL error 6)
#> Warning: SetRawNoDataValue() not implemented (GDAL error 6)

units(rast("test/path/out0.zarr"))
#> [1] "m" "m" "m"
units(rast("/vsizip/test/path/out1.zip/out"))
#> [1] "m" "m" "m"
units(rast("/vsizip/{test/path/out2}/out"))
#> [1] "m" "m" "m"

unzip("test/path/out2", exdir = "test/path/out")
cat(readLines("test/path/out/out.aux.json"), sep = "\n")
#> {
#> "time":["2025-01-05","2025-01-05","2025-01-05"],
#> "timestep":"days",
#> "unit":["m","m","m"]
#> }
```

This somewhat resolves the original issue from https://github.com/rspatial/terra/issues/1629 where an auxiliary file used for storing metadata for most formats would not be written or read. However, it does not resolve the issue from #1629 of deleting existing zip files created by using /vsizip/ to write with overwrite=TRUE. I think it could be technically possible to identify simple cases, but detecting all the different possibilities of nesting of files and folder structure, with or without .zip extension, makes it difficult to resolve in general, and you don't want to accidentally delete parent directories. 