### PR TITLE
fix bashisms

### DIFF
--- a/configure
+++ b/configure
@@ -2274,15 +2274,15 @@ RVER_MAJOR=`echo ${RVER} | cut  -f1 -d"."`
 RVER_MINOR=`echo ${RVER} | cut  -f2 -d"."`
 RVER_PATCH=`echo ${RVER} | cut  -f3 -d"."`
 
-if test $RVER_MAJOR = "development"; then
+#if test [$RVER_MAJOR = "development"]; then
     CXX=`"${RBIN}" CMD config CXX`
-else
-    if test $RVER_MAJOR -lt 3 -o $RVER_MAJOR -eq 3 -a $RVER_MINOR -lt 3; then
-        as_fn_error $? "terra is not compatible with R versions before 3.3.0" "$LINENO" 5
-    else
-        CXX=`"${RBIN}" CMD config CXX`
-    fi
-fi
+#else
+#    if test [$RVER_MAJOR -lt 3] -o [$RVER_MAJOR -eq 3 -a $RVER_MINOR -lt 3]; then
+#        AC_MSG_ERROR([terra is not compatible with R versions before 3.3.0])
+#    else
+#        CXX=`"${RBIN}" CMD config CXX`
+#    fi
+#fi
 
 # pick all flags for testing from R
 : ${CC=`"${RBIN}" CMD config CC`}
@@ -2426,7 +2426,8 @@ else
 printf "%s\n" "yes" >&6; }
 fi
 
-if test ${GDAL_MAJ_VER} -eq 3 -a ${GDAL_MIN_VER} -eq 6 -a ${GDAL_PATCH_VER} -eq 0 ; then
+#if test [${GDAL_MAJ_VER} -eq 3] -a [${GDAL_MIN_VER} -eq 6] -a [${GDAL_PATCH_VER} -eq 0] ; then
+if test "${GDAL_VERSION}" = "3.6.0" ; then
   as_fn_error $? "GDAL version 3.6.0 has been withdrawn, please update GDAL" "$LINENO" 5
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -19,15 +19,15 @@ RVER_MAJOR=`echo ${RVER} | cut  -f1 -d"."`
 RVER_MINOR=`echo ${RVER} | cut  -f2 -d"."`
 RVER_PATCH=`echo ${RVER} | cut  -f3 -d"."`
 
-if test [$RVER_MAJOR = "development"]; then
+#if test [$RVER_MAJOR = "development"]; then
     CXX=`"${RBIN}" CMD config CXX`
-else
-    if test [$RVER_MAJOR -lt 3] -o [$RVER_MAJOR -eq 3 -a $RVER_MINOR -lt 3]; then
-        AC_MSG_ERROR([terra is not compatible with R versions before 3.3.0])
-    else
-        CXX=`"${RBIN}" CMD config CXX`
-    fi
-fi
+#else
+#    if test [$RVER_MAJOR -lt 3] -o [$RVER_MAJOR -eq 3 -a $RVER_MINOR -lt 3]; then
+#        AC_MSG_ERROR([terra is not compatible with R versions before 3.3.0])
+#    else
+#        CXX=`"${RBIN}" CMD config CXX`
+#    fi
+#fi
 
 # pick all flags for testing from R
 : ${CC=`"${RBIN}" CMD config CC`}
@@ -107,7 +107,8 @@ else
    AC_MSG_RESULT(yes)
 fi
 
-if test [${GDAL_MAJ_VER} -eq 3] -a [${GDAL_MIN_VER} -eq 6] -a [${GDAL_PATCH_VER} -eq 0] ; then
+#if test [${GDAL_MAJ_VER} -eq 3] -a [${GDAL_MIN_VER} -eq 6] -a [${GDAL_PATCH_VER} -eq 0] ; then
+if test "${GDAL_VERSION}" = "3.6.0" ; then
   AC_MSG_ERROR([GDAL version 3.6.0 has been withdrawn, please update GDAL])
 fi
 


### PR DESCRIPTION
See https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/terra-00check.html. First is unneeded, as R >=3.5.0 is required in DESCRIPTION. The second is needed, and the edit works, checked both with _R_CHECK_BASHISMS_=true _R_CHECK_BASHISMS_EXTRA_=true and R-devel, and against a doctored gdal-config reporting 3.6.0.