### PR TITLE
Update divide.R

### DIFF
--- a/R/divide.R
+++ b/R/divide.R
@@ -83,26 +83,26 @@ setMethod("divide", signature(x="SpatRaster"),
 			if (length(n) > 1) {
 				for (i in 1:length(n)) {
 					if (n[i] == 1) {
-						out <- unlist(lapply(out, \(i) splitNS(i)))
+						out <- unlist(lapply(out, function(i) splitNS(i)))
 					} else if (n[i] == -1) {
-						out <- unlist(lapply(out, \(i) splitWE(i)))
+						out <- unlist(lapply(out, function(i) splitWE(i)))
 					} else if (n[i] == 2) {
-						out <- unlist(lapply(out, \(i) splitNS3(i)))
+						out <- unlist(lapply(out, function(i) splitNS3(i)))
 					} else { # if (n[i] == -2) {
-						out <- unlist(lapply(out, \(i) splitWE3(i)))
+						out <- unlist(lapply(out, function(i) splitWE3(i)))
 					}
 				}
 			} else {
 				for (i in 1:n) {
 					if (north) {
-						out <- unlist(lapply(out, \(s) splitNS(s)))
+						out <- unlist(lapply(out, function(s) splitNS(s)))
 					} else {
-						out <- unlist(lapply(out, \(s) splitWE(s)))
+						out <- unlist(lapply(out, function(s) splitWE(s)))
 					}
 					north <- !north
 				}  
 			}
-			out <- lapply(out, \(i) as.polygons(ext(i))) |> vect()
+			out <- lapply(out, function(i) as.polygons(ext(i))) |> vect()
 			crs(out) <- crs(out)
 		}
 		out$zones <- 1:nrow(out)


### PR DESCRIPTION
I am all for the lambda function syntax, but we still run tests on R 3.6.3 (we probably will continue to do this until at least Ubuntu 20.04 end of support in April 2025), and terra min R version is still 3.5.0.

The package fails to parse on R 3.6.3 with `\(x) ...` style syntax:

```
...
  Error in parse(outFile) : 
    /tmp/RtmpugU74t/R.INSTALL2be073be0aac/terra/R/divide.R:86:75: unexpected input
  85:                                         if (n[i] == 1) {
  86:                                                 out <- unlist(lapply(out, \
                                                                                ^
  ERROR: unable to collate and parse R files for package ‘terra’
...
 ```