### PR TITLE
Generalize raster metadata 

### DIFF
--- a/src/read_gdal.cpp
+++ b/src/read_gdal.cpp
@@ -1028,7 +1028,7 @@ Rcpp::Rcout << "flipped\n";
 			}
 		}
 
-		if ((gdrv=="netCDF") || (gdrv == "HDF5") || (gdrv == "GRIB") || (gdrv == "GTiff")) {
+		// if ((gdrv=="netCDF") || (gdrv == "HDF5") || (gdrv == "GRIB") || (gdrv == "GTiff")) {
 			char **m = poBand->GetMetadata();
 			while (m != nullptr && *m != nullptr) {
 				bandmeta[i].push_back(*m++);
@@ -1050,7 +1050,7 @@ Rcpp::Rcout << "flipped\n";
 					}
 				}
 			}
-		}
+		// }
 
 		int success;
 	//	double naflag = poBand->GetNoDataValue(&success);

--- a/src/read_gdal.cpp
+++ b/src/read_gdal.cpp
@@ -1297,7 +1297,7 @@ Rcpp::Rcout << "flipped\n";
 	s.hasValues = true;
 	setSource(s);
 
-	if ((!metadata.empty()) && ((gdrv=="netCDF") || (gdrv == "HDF5"))) {
+	if ((!metadata.empty())) {
 		std::vector<std::string> tagnames, tagvalues;
 //		std::string stag = s.source_name + "#TAG_";
 		std::string stag = s.source_name + "#";

--- a/src/write_gdal.cpp
+++ b/src/write_gdal.cpp
@@ -614,14 +614,14 @@ bool SpatRaster::writeStartGDAL(SpatOptions &opt, const std::vector<std::string>
 
 	bool scoffwarning = false;
 
-	if (driver == "GTiff") {
+	// if (driver == "GTiff") {
 		std::vector<std::string> m = getTags();
 		if (m.size() > 0) {
 			for (size_t i=0; i<m.size(); i+=2) {
 				poDS->SetMetadataItem(m[i].c_str(), m[i+1].c_str(), "USER_TAGS");
 			}
 		}
-	}
+	// }
 
 	std::vector<std::string> tstr, ustr;
 	bool wtime = false;
@@ -676,7 +676,7 @@ bool SpatRaster::writeStartGDAL(SpatOptions &opt, const std::vector<std::string>
 		*/
 		poBand->SetDescription(nms[i].c_str());
 
-		if (driver == "GTiff") {
+		// if (driver == "GTiff") {
 			std::vector<std::string> m = getLyrTags({i});
 			if (m.size() > 0) {
 				for (size_t j=0; j<m.size(); j+=3) {
@@ -694,7 +694,7 @@ bool SpatRaster::writeStartGDAL(SpatOptions &opt, const std::vector<std::string>
 			if (wunit) {
 				poBand->SetMetadataItem("UNIT", ustr[i].c_str());				
 			}
-		}
+		// }
 
 
 		if ((i==0) || (driver != "GTiff")) {


### PR DESCRIPTION
Following up on https://github.com/rspatial/terra/pull/1696#issuecomment-2581046017 I did some analysis on removing driver restrictions for reading and writing raster metadata. 

It seems that with removing a few conditional statements we can write either .aux.xml or internal metadata for time and units for many more drivers than just GTiff. 

I wrote a routine (see [this Gist](https://gist.github.com/brownag/db0b5d5c7d128896cff48bc95eb95b35)) to attempt to write and read a raster with metadata using all available raster drivers. The .aux.json is deleted prior to read, so any metadata that are read are those written using GDAL `SetMetadataItem()`, not the terra-specific .aux.json function.

The following is from testing with GDAL 3.10.0 and config option `GDAL_PAM_ENABLED=YES` (default). 

Of `80` raster drivers with apparent write capability, I found `2` that I would omit from the test (MEM and VRT). `10` additional drivers failed to write--some of these are expected, like OpenFileGDB, which does not support write for raster, the others need more specific configuration to make copies of existing data sources or I don't have a good way to test them in this context. 

I found `28` drivers can read or write all of the current metadata elements including unit, time, dataset, band user tags. One driver (GPKG) can write all but the band-level user tags. An additional 13 drivers read and write units and time only. This gives a total of `42` drivers that can read and write units and time without significant changes to current code. `32` drivers can read and write dataset user tags, and `31` can do band-level user tags. `55` drivers write some sort of .aux.xml file, of which `50` contain both units and time, and `53` only time. `33` write dataset and band tags to .aux.xml files. So, there appear to be some cases where tags are written but not read. 

Is there anywhere I have missed where there may be some logic limiting read/write for these metadata items? I have tried playing with the logic in read_gdal.cpp but so far have only made the above results the same or worse.
https://github.com/rspatial/terra/blob/2a3aa0b2fc1af961ed1a19b2dd2dea9d902013dd/src/read_gdal.cpp#L1261-L1290

In general it seems that DATE_TIME is better supported than UNIT, and TIMESTAMP/TIMEUNIT is slightly better supported than DATE_TIME. Possibly of interest to highlight: 5 drivers ("COG", "GPKG", "GTiff", "netCDF", "PCIDSK") support read/write of internal metadata for units and time. 

While I think this is an improvement over only writing GDAL metadata with GTiff, it is not as consistent as I would hope. It does seem that the .aux.json file provides some consistency at the cost of being external to GDAL. 

I am not sure yet why some drivers don't write .aux.xml or internal metadata, there is probably not one reason, I guess the `SetMetadataItem()`/`GetMetadata()` calls etc. are just ignored/not defined in some drivers. It is documented that some drivers do not support them, but it seems like a few of the problem drivers should work better than they do. 

I looked into my Zarr anecdote from https://github.com/rspatial/terra/pull/1696#issuecomment-2581046017 and found that `writeRaster()`/`SetMetadataItem()` appear to not write to the internal .zmetadata file, but I _could_ write custom metadata for Zarr with the `-mo` flag to gdal_translate. While I could write e.g. UNIT metadata manually, it was still not read with `rast()`. I may investigate a bit more how gdal_translate is getting/setting metadata to try and figure that out.
