### PR TITLE
map.pal warning (not error) when random n>433

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -333,7 +333,7 @@ shade <- function(slope, aspect, angle=45, direction=0, normalize=FALSE, filenam
 map.pal <- function(name, n=50, ...) { 
 	n <- round(n)
 	if (n < 1) {
-		error("map.pal", "n should be > 0")	
+		error("map.pal", "n should be >= 1")	
 	}
 	f <- system.file("colors/palettes.rds", package="terra")
 	v <- readRDS(f)
@@ -349,7 +349,8 @@ map.pal <- function(name, n=50, ...) {
 		}
 	} else if (name == "random") {
 		if (n > 433) {
-			error("map.pal", "you cannot get more than 433 random colors")
+			warning("map.pal", "you cannot get > 433 random colors; using n=433 instead")
+			n <- 433
 		}
 		s <- sample(grDevices::colors()[grep('gr(a|e)y', grDevices::colors(), invert = TRUE)], n)
 		rgb(t(grDevices::col2rgb(s))/255)


### PR DESCRIPTION
It's probably not necessary to break the code just because of a larger `n` than possible, e.g. when we do `plot(my_object, col = map.pal("random", nrow(my_object)))`. I'd just coerce `n` to the maximum possible value, with a message or warning.