### PR TITLE
Remove 'concave_polygons' from list of allowed hull types

### DIFF
--- a/R/geom.R
+++ b/R/geom.R
@@ -354,7 +354,7 @@ setMethod("crop", signature(x="SpatVector", y="ANY"),
 
 setMethod("hull", signature(x="SpatVector"),
 	function(x, type="convex", by="", param=1, allowHoles=TRUE, tight=TRUE) {
-		type <- match.arg(tolower(type), c("convex", "rectangle", "circle", "concave_ratio", "concave_length", "concave_polygons"))
+		type <- match.arg(tolower(type), c("convex", "rectangle", "circle", "concave_ratio", "concave_length"))
 		x@pntr <- x@pntr$hull(type, by[1], param, allowHoles, tight)
 		messages(x, "hull")
 	}


### PR DESCRIPTION
An error message for `hull()` states that "concave_polygons" is a valid option for `hull()` - however, this is not the case:

``` r
library(terra)
#> terra 1.8.26
v <- vect(system.file("ex/lux.shp", package = "terra"))
h <- hull(v, type = "abcd")
#> Error in match.arg(tolower(type), c("convex", "rectangle", "circle", "concave_ratio", : 'arg' should be one of "convex", "rectangle", "circle", "concave_ratio", "concave_length", "concave_polygons"
h <- hull(v, type = "concave_polygons")
#> Error: [hull] unknown hull type
```

<sup>Created on 2025-04-16 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

There's a mismatch between the R and C++ methods:

https://github.com/rspatial/terra/blob/85fa6ad6443f6713f83bbc98d681acc4faf25715/R/geom.R#L357
https://github.com/rspatial/terra/blob/85fa6ad6443f6713f83bbc98d681acc4faf25715/src/geos_methods.cpp#L1014

This commit simply removes "concave_polygons" from the list of valid options for `hull()`.

