### PR TITLE
Test on Win2025

### DIFF
--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -22,6 +22,8 @@ jobs:
         config:
           - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
+          - {os: windows-2025,   r: 'release'}
+          - {os: windows-2025,   r: 'devel'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
 


### PR DESCRIPTION
We found on r-universe that this package crashes on load on Windows 2025 (but not on Windows 2022).

```
*** installing help indices
*** copying figures
** building package indices
** testing if installed package can be loaded from temporary location
ERROR: loading failed
* removing 'D:/a/terra/terra/check/terra.Rcheck/terra
```
 
 I have no idea how to debug this with the current Rtools, perhaps @kalibera can help.