### PR TITLE
dev.hold() for animate

### DIFF
--- a/R/animate.R
+++ b/R/animate.R
@@ -21,6 +21,7 @@ function(x, pause=0.25, main, range, maxcell=50000, n=1, ...) {
     while (reps < n) {
         plot(x[[i]], main = main[i], range=range, maxcell=Inf, ...)
         grDevices::dev.flush()
+	grDevices::dev.hold()
         Sys.sleep(pause)
         i <- i + 1
         if (i > nl) {


### PR DESCRIPTION
I get much better effect with dev.hold to avoid flashing, .eg. (tested on Windows and via X over ssh)

```
s <- rast(system.file("ex/logo.tif", package="terra"))   

## inline modification of terra::animate to apply dev.hold without recompiling
anim <- function(x, pause=0.25, main, range, maxcell=50000, n=1, ...) {
  if (missing(main)) {
    main <- names(x)
  }
  
  #x <- spatSample(x, size=maxcell, method="regular", as.raster=TRUE, warn=FALSE)
  x <- terra:::sampleRaster(x, maxcell, method="regular", replace=FALSE, ext=NULL, warn=FALSE, overview=TRUE)
  
  if (missing(range)) {
    mnmx <- minmax(x)
    range <- c(min(mnmx[1,]), max(mnmx[2,]))
  }
  
  nl <- nlyr(x)
  n <- max(1, round(n))
  i <- 1
  reps <- 0
  while (reps < n) {
    plot(x[[i]], main = main[i], range=range, maxcell=Inf, ...)
    grDevices::dev.flush()
    grDevices::dev.hold()
    Sys.sleep(pause)
    i <- i + 1
    if (i > nl) {
      i <- 1
      reps <- reps+1
    }
  }
}
anim(s, n=10)

```