### PR TITLE
Fix setting up proj search paths.

### DIFF
--- a/src/RcppFunctions.cpp
+++ b/src/RcppFunctions.cpp
@@ -561,7 +561,7 @@ bool set_proj_search_paths(std::vector<std::string> paths) {
 	for (size_t i = 0; i < paths.size(); i++) {
 		cpaths[i] = (char *) (paths[i].c_str());
 	}
-	cpaths[cpaths.size()] = NULL;
+	cpaths[cpaths.size()-1] = NULL;
 	OSRSetPROJSearchPaths(cpaths.data());
 	return true;
 #else


### PR DESCRIPTION
This fixes an out-of-bounds write when setting up proj search paths. It is the cause for crashes reported in https://github.com/rspatial/terra/issues/1813.

