### PR TITLE
vrt: Add support for `set_names` with `options="-separate"`

### DIFF
--- a/R/tiles.R
+++ b/R/tiles.R
@@ -8,14 +8,14 @@ setMethod("makeTiles", signature(x="SpatRaster"),
 		if (inherits(y, "SpatRaster")) {
 			ff <- x@pntr$make_tiles(y@pntr, extend[1], buffer, na.rm[1], filename, opt)
 		} else if (inherits(y, "SpatVector")) {
-			ff <- x@pntr$make_tiles_vect(y@pntr, extend[1], buffer, na.rm[1], filename, opt)		
+			ff <- x@pntr$make_tiles_vect(y@pntr, extend[1], buffer, na.rm[1], filename, opt)
 		} else if (is.numeric(y)) {
 			if (length(y) > 2) {
 				error("makeTiles", "expected one or two numbers")
 			}
 			y <- rep_len(y, 2)
 			y <- aggregate(rast(x), y)
-			ff <- x@pntr$make_tiles(y@pntr, extend[1], buffer, na.rm[1], filename, opt)			
+			ff <- x@pntr$make_tiles(y@pntr, extend[1], buffer, na.rm[1], filename, opt)
 		} else {
 			error("makeTiles", "y must be numeric or a SpatRaster or SpatVector")
 		}
@@ -32,7 +32,7 @@ setMethod("getTileExtents", signature(x="SpatRaster"),
 		if (inherits(y, "SpatRaster")) {
 			e <- x@pntr$get_tiles_ext(y@pntr, extend[1], buffer)
 		} else if (inherits(y, "SpatVector")) {
-			e <- x@pntr$get_tiles_ext_vect(y@pntr, extend[1], buffer)		
+			e <- x@pntr$get_tiles_ext_vect(y@pntr, extend[1], buffer)
 		} else if (is.numeric(y)) {
 			if (length(y) > 2) {
 				error("getTileExtents", "expected one or two numbers")
@@ -75,13 +75,17 @@ setMethod("vrt", signature(x="character"),
 		r <- rast()
 		if (is.null(options)) {
 			options=""[0]
-		} 
+		}
 		f <- r@pntr$make_vrt(x, options, opt)
 		messages(r, "vrt")
 		messages(opt, "vrt")
 		if (set_names) {
 			v <- readLines(f)
-			nms <- names(rast(x[1]))
+			if ("-separate" %in% options) {
+			  nms <- names(rast(x))
+			} else {
+			  nms <- names(rast(x[1]))
+			}
 			i <- grep("band=", v)
 			if (length(i) == length(nms)) {
 				nms <- paste0("<Description>", nms, "</Description>")
@@ -101,9 +105,9 @@ setMethod("vrt", signature(x="character"),
 setMethod("vrt", signature(x="SpatRasterCollection"),
 	function(x, filename="", options=NULL, overwrite=FALSE, return_filename=FALSE) {
 		opt <- spatOptions(filename, overwrite=overwrite)
-		if (is.null(options)) {	
+		if (is.null(options)) {
 			options=""[0]
-		} 
+		}
 		f <- x@pntr$make_vrt(options, FALSE, opt)
 		messages(x, "vrt")
 		if (return_filename) {
@@ -124,7 +128,7 @@ vrt_tiles <- function(x) {
 	}
 	x <- grep(".vrt$", x, ignore.case =TRUE, value=TRUE)
 	if (length(x) == 0) {
-		error("vrt_sources", 'no filenames with extension ".vrt"')	
+		error("vrt_sources", 'no filenames with extension ".vrt"')
 	}
 	tiles <- lapply(x, function(f) {
 			v <- readLines(f)

--- a/man/vrt.Rd
+++ b/man/vrt.Rd
@@ -8,8 +8,8 @@
 
 \title{Virtual Raster Dataset}
 
-\description{ 
-Create a Virtual Raster Dataset (VRT) from a collection of file-based raster datasets (tiles). See 
+\description{
+Create a Virtual Raster Dataset (VRT) from a collection of file-based raster datasets (tiles). See
 \href{https://gdal.org/en/latest/programs/gdalbuildvrt.html}{gdalbuildvrt} for details.
 }
 
@@ -21,11 +21,11 @@ Create a Virtual Raster Dataset (VRT) from a collection of file-based raster dat
 
 \arguments{
   \item{x}{SpatRasterCollection or character vector with filenames of raster "tiles". That is, files that have data for, typically non-overlapping, sub-regions of an raster. See \code{\link{makeTiles}}}
-  \item{filename}{character. output VRT filename}  
+  \item{filename}{character. output VRT filename}
   \item{options}{character. All arguments as separate vector elements. Options as for \href{https://gdal.org/en/latest/programs/gdalbuildvrt.html}{gdalbuildvrt}}
   \item{overwrite}{logical. Should \code{filename} be overwritten if it exists?}
-  \item{set_names}{logical. Add the layer names of the first tile to the vrt?}
-  \item{return_filename}{logical. If \code{TRUE} the filename is returned, otherwise a SpatRaster is returned}  
+  \item{set_names}{logical. Add the layer names of the first tile to the vrt? If \code{options} includes \code{"-separate"} the name of each source file is added, and each input goes into a separate band in the VRT dataset}
+  \item{return_filename}{logical. If \code{TRUE} the filename is returned, otherwise a SpatRaster is returned}
 }
 
 \value{
@@ -37,7 +37,7 @@ A VRT can reference very many datasets. These are not all opened at the same tim
 }
 
 \seealso{
-\code{\link{makeTiles}} to create tiles; \code{\link{makeVRT}} to create a .vrt file for a binary raster file that does not have a header file. \code{\link{vrt_tiles}} to get the filenames of the tiles in a VRT. 
+\code{\link{makeTiles}} to create tiles; \code{\link{makeVRT}} to create a .vrt file for a binary raster file that does not have a header file. \code{\link{vrt_tiles}} to get the filenames of the tiles in a VRT.
 }
 
 \examples{


### PR DESCRIPTION
Hi @rhijmans!

This PR adds to `vrt(<character>)` support for `set_names` with [`options="-separate"`](https://gdal.org/en/stable/programs/gdalbuildvrt.html#cmdoption-gdalbuildvrt-separate).
- The existing logic for `set_names` works great for tiled datasets, but I think for the overlapping case it can be altered.
- The PR is mainly to demonstrate a behavior that would be convenient for a few more situations. Feel free to close and implement it differently or not at all

Thank you for your consideration. 


With this PR we would get:
    
``` r
library(terra)
#> terra 1.8.56

x <- rast(system.file("ex", "elev.tif", package = "terra"))

# create 3 band dataset (each band different source)
x2 <- c(x, x * 2, x * 3)
names(x2) <- LETTERS[1:3]
x3 <- rast(lapply(names(x2), function(n) {
    writeRaster(x2[[n]], tempfile(fileext = ".tif"))
}))

# now works
res1 <- vrt(sources(x3), options = "-separate", set_names = TRUE)
res1
#> class       : SpatRaster 
#> size        : 90, 95, 3  (nrow, ncol, nlyr)
#> resolution  : 0.008333333, 0.008333333  (x, y)
#> extent      : 5.741667, 6.533333, 49.44167, 50.19167  (xmin, xmax, ymin, ymax)
#> coord. ref. : lon/lat WGS 84 (EPSG:4326) 
#> source      : spat_d9521ace7116_55634_o8up7yuDdJ6XHBX.vrt 
#> names       :   A,    B,    C 
#> min values  : 141,  282,  423 
#> max values  : 547, 1094, 1641

# still works
x4 <- makeTiles(x3, 10)
res2 <- vrt(x4, set_names = TRUE)
res2
#> class       : SpatRaster 
#> size        : 90, 95, 3  (nrow, ncol, nlyr)
#> resolution  : 0.008333333, 0.008333333  (x, y)
#> extent      : 5.741667, 6.533333, 49.44167, 50.19167  (xmin, xmax, ymin, ymax)
#> coord. ref. : lon/lat WGS 84 (EPSG:4326) 
#> source      : spat_d952bed8f77_55634_zxzxx9jyyx6UnnI.vrt 
#> names       :   A,   B,   C 
#> min values  : NaN, NaN, NaN 
#> max values  : NaN, NaN, NaN

# values match (excluding NA vs. NaN)
all(values(res1) == values(res2), na.rm = TRUE)
#> [1] TRUE
```

## Previous behavior:
    
<details>
    
``` r
library(terra)
#> terra 1.8.56

x <- rast(system.file("ex", "elev.tif", package = "terra"))

# create 3 band dataset (each band different source)
x2 <- c(x, x * 2, x * 3)
names(x2) <- LETTERS[1:3]

x3 <- rast(lapply(names(x2), function(n) {
    writeRaster(x2[[n]], tempfile(fileext = ".tif"))
}))

# names not preserved
res1 <- vrt(sources(x3), options = "-separate", set_names = TRUE)
res1
#> class       : SpatRaster 
#> size        : 90, 95, 3  (nrow, ncol, nlyr)
#> resolution  : 0.008333333, 0.008333333  (x, y)
#> extent      : 5.741667, 6.533333, 49.44167, 50.19167  (xmin, xmax, ymin, ymax)
#> coord. ref. : lon/lat WGS 84 (EPSG:4326) 
#> source      : spat_d38454d06bd6_54148_o8up7yuDdJ6XHBX.vrt 
#> names       : spat_d3845~DdJ6XHBX_1, spat_d3845~DdJ6XHBX_2, spat_d3845~DdJ6XHBX_3 
#> min values  :                   141,                   282,                   423 
#> max values  :                   547,                  1094,                  1641

# works (returns nodata as NaN)
x4 <- makeTiles(x3, 10)
res2 <- vrt(x4, set_names = TRUE)
res2
#> class       : SpatRaster 
#> size        : 90, 95, 3  (nrow, ncol, nlyr)
#> resolution  : 0.008333333, 0.008333333  (x, y)
#> extent      : 5.741667, 6.533333, 49.44167, 50.19167  (xmin, xmax, ymin, ymax)
#> coord. ref. : lon/lat WGS 84 (EPSG:4326) 
#> source      : spat_d38411fd7cec_54148_zxzxx9jyyx6UnnI.vrt 
#> names       :   A,   B,   C 
#> min values  : NaN, NaN, NaN 
#> max values  : NaN, NaN, NaN


# values match (excluding NA vs. NaN)
all(values(res1) == values(res2), na.rm = TRUE)
#> [1] TRUE
```

</details>
