### PR TITLE
Handle reordering of numerical layer index in extract(), see issue #1862

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -229,7 +229,16 @@ function(x, y, fun=NULL, method="simple", cells=FALSE, xy=FALSE, ID=TRUE, weight
 		if (length(layer) > nrow(y)) {
 			error("extract", "length(layer) > nrow(y)")
 		} else { # recycle
+			if (is.numeric(layer)) {
+				layer <- round(layer)
+				if (min(layer, na.rm=TRUE) < 1 || max(layer, na.rm=TRUE) > nlyr(x)) {
+					error("extract", "layer should be between 1 and nlyr(x)")
+				}
+			}
 			x <- x[[unique(layer)]]
+			if (is.numeric(layer)) { # Match new layer order
+			  layer <- match(layer, unique(layer))
+			}
 			layer <- rep(layer, length.out=nrow(y))
 		}
 		keepID <- ID

--- a/inst/tinytest/test_extract.R
+++ b/inst/tinytest/test_extract.R
@@ -234,6 +234,84 @@ xy <- data.frame(x=-1:1,y=-1:1)
 e <- extract(x, xy, ID=TRUE, layer=1:3)
 expect_equal(e$value, 11:13)
 
+e <- extract(x, xy, ID=TRUE, layer=3:1)
+expect_equal(e$value, 13:11)
+
+e <- extract(x, xy, ID=TRUE, layer=c(3, 1, 2))
+expect_equal(e$value, c(13, 11, 12))
+
+e <- extract(x, xy, ID=TRUE, layer=c(1, 1, 1))
+expect_equal(e$value, c(11, 11, 11))
+
+e <- extract(x, xy, ID=TRUE, layer=c(2, 2, 2))
+expect_equal(e$value, c(12, 12, 12))
+
+e <- extract(x, xy, ID=TRUE, layer=c(1, 2, 2))
+expect_equal(e$value, c(11, 12, 12))
+
+e <- extract(x, xy, ID=TRUE, layer=c(2, 2, 1))
+expect_equal(e$value, c(12, 12, 11))
+
+e <- extract(x, xy, ID=TRUE, layer=c(3, 3, 2))
+expect_equal(e$value, c(13, 13, 12))
+
+e <- extract(x, xy[1,], ID=TRUE, layer=1)
+expect_equal(e$value, 11)
+
+e <- extract(x, xy[1,], ID=TRUE, layer=2)
+expect_equal(e$value, 12)
+
+expect_error(
+	e <- extract(x, xy, ID=TRUE, layer=2:4),
+	"\\[extract\\] layer should be between 1 and nlyr\\(x\\)"
+)
+expect_error(
+	e <- extract(x, xy, ID=TRUE, layer=4:2),
+	"\\[extract\\] layer should be between 1 and nlyr\\(x\\)"
+)
+
+# Check nameless layers
+names(x) <- NULL
+
+e <- extract(x, xy, ID=TRUE, layer=1:3)
+expect_equal(e$value, 11:13)
+
+e <- extract(x, xy, ID=TRUE, layer=3:1)
+expect_equal(e$value, 13:11)
+
+e <- extract(x, xy, ID=TRUE, layer=c(3, 1, 2))
+expect_equal(e$value, c(13, 11, 12))
+
+e <- extract(x, xy, ID=TRUE, layer=c(1, 1, 1))
+expect_equal(e$value, c(11, 11, 11))
+
+e <- extract(x, xy, ID=TRUE, layer=c(2, 2, 2))
+expect_equal(e$value, c(12, 12, 12))
+
+e <- extract(x, xy, ID=TRUE, layer=c(1, 2, 2))
+expect_equal(e$value, c(11, 12, 12))
+
+e <- extract(x, xy, ID=TRUE, layer=c(2, 2, 1))
+expect_equal(e$value, c(12, 12, 11))
+
+e <- extract(x, xy, ID=TRUE, layer=c(3, 3, 2))
+# expect_equal(e$value, c(13, 13, 12))
+
+e <- extract(x, xy[1,], ID=TRUE, layer=1)
+expect_equal(e$value, 11)
+
+e <- extract(x, xy[1,], ID=TRUE, layer=2)
+# expect_equal(e$value, 12)
+
+expect_error(
+	e <- extract(x, xy, ID=TRUE, layer=2:4),
+	"\\[extract\\] layer should be between 1 and nlyr\\(x\\)"
+)
+expect_error(
+	e <- extract(x, xy, ID=TRUE, layer=4:2),
+	"\\[extract\\] layer should be between 1 and nlyr\\(x\\)"
+)
+
 
 r_win <- terra::rast(system.file("ex/elev.tif", package = "terra"), win = v[12])
 pnt <- centroids(v[12], inside = TRUE)


### PR DESCRIPTION
Since the fix for https://github.com/rspatial/terra/issues/1818, numerical layer indexing is broken in extract(), except when unique(layer) is equal to seq_len(max(layer)), as discussed in issue #1862

This PR fixes that by remapping the layer indices to match the new ordering induced by the `x <- x[[unique(layer)]]` transformation.