### PR TITLE
SpatVector: construct from list of raw vectors representing WKB geoms

### DIFF
--- a/R/vect.R
+++ b/R/vect.R
@@ -426,13 +426,24 @@ setMethod("vect", signature(x="data.frame"),
 
 setMethod("vect", signature(x="list"),
 	function(x, type="points", crs="") {
-		x <- lapply(x, function(i) {
-			if (inherits(i, "SpatVector")) return(i)
-			vect(i, type=type)
-		})
-		x <- svc(x)
-		v <- methods::new("SpatVector")
-		v@pntr <- x@pntr$append()
+		if (typeof(x[[1]]) == "raw") {
+			# TODO is this poor type check redundant given the constructor signature?
+			if (!is.null(type)) {
+				warn(
+					"vect",	"ignoring `type` argument for WKB, set to null to silence"
+				)
+			}
+			v <- methods::new("SpatVector")
+			v@pntr <- SpatVector$new(x)
+		} else {
+			x <- lapply(x, function(i) {
+				if (inherits(i, "SpatVector")) return(i)
+				vect(i, type=type)
+			})
+			x <- svc(x)
+			v <- methods::new("SpatVector")
+			v@pntr <- x@pntr$append()
+		}
 		if (crs != "") {
 			crs(v) <- crs
 		}

--- a/inst/tinytest/test_vect-geom.R
+++ b/inst/tinytest/test_vect-geom.R
@@ -6,6 +6,10 @@ listofraw <- geom(lux[1:2, ], wkb = TRUE)
 wkb <- listofraw[[1]]
 hex <- geom(lux[1, ], hex = TRUE)
 
+expect_equal(
+  vect(listofraw, type = NULL, crs = crs(lux)),
+  lux[1:2, character()]
+)
 
 expect_equal(typeof(listofraw), "list") 
 expect_equal(typeof(wkb), "raw")

--- a/src/RcppModule.cpp
+++ b/src/RcppModule.cpp
@@ -432,6 +432,8 @@ RCPP_MODULE(spat){
 	class_<SpatVector>("SpatVector")
 		.constructor()
 		.constructor<SpatExtent, std::string>()
+		// TODO is std::vector<std::vector<unsigned char>> cheaper? check if that works
+		.constructor<Rcpp::ListOf<Rcpp::RawVector>>()
 		.constructor<std::vector<std::string>>()
 
 

--- a/src/spatVector.h
+++ b/src/spatVector.h
@@ -19,6 +19,7 @@
 #define SPATVECTOR_GUARD
 
 #include "spatDataframe.h"
+#include "Rcpp.h"
 
 #ifdef useGDAL
 #include "gdal_priv.h"
@@ -124,6 +125,7 @@ class SpatVector {
 		SpatVector(SpatGeom g);
 		SpatVector(SpatExtent e, std::string crs);
 		SpatVector(std::vector<double> x, std::vector<double> y, SpatGeomType g, std::string crs);
+		SpatVector(Rcpp::ListOf<Rcpp::RawVector> wkb_raw);
 		SpatVector(std::vector<std::string> wkt);
 		virtual ~SpatVector(){}
 


### PR DESCRIPTION
Hi! I thought I'd try my hand at an implementation for a SpatVector constructor method that takes in a list of WKB geometries. While there currently is a method for dumping geometries to WKB raw, there is no way to get them back into a SpatVector.

I'm unsure how this functionality should be exposed in R. I did also think of writing a coercion function, but decided against it on grounds of more interface flexibility in the vect() constructor method.

I have left two TODOs in the code that I want to address:

- [ ] Currently I'm doing a very simple (and thus cheap) typecheck to push the iteration over long lists to C++. This also means that there's a potentially weird mix of dispatch logic in place where a normal list is dispatched by element, but for a list with a raw element at the beginning, it's treated as a vector would be.
- [ ] I'm relying on the `Rcpp::ListOf` type signature - I haven't got the time to test whether that actually does a type check across all elements. I don't think there's any sort of performance penalty for using an Rcpp object instead of a `std::vector`, since it's read-only. However, I might have gone against some basic rule in terra development.

Hope I didn't miss any contributor guidance! I tested locally, but had to guess a bit on how to get set up.