### PR TITLE
mention global() in SeeAlso

### DIFF
--- a/man/app.Rd
+++ b/man/app.Rd
@@ -42,7 +42,7 @@ SpatRaster
 To speed things up, parallelization is supported, but this is often not helpful, and it may actually be slower. There is only a speed gain if you have many cores (> 8) and/or a very complex (slow) function \code{fun}. If you write \code{fun} yourself, consider supplying a \code{cppFunction} made with the Rcpp package instead (or go have a cup of tea while the computer works for you).
 }
 
-\seealso{ \code{\link{lapp}}, \code{\link{tapp}}, \code{\link[terra]{Math-methods}}, \code{\link{roll}} }
+\seealso{ \code{\link{lapp}}, \code{\link{tapp}}, \code{\link[terra]{Math-methods}}, \code{\link{roll}}; \code{\link{global}} to summarize the values of a single SpatRaster }
 
 
 \examples{


### PR DESCRIPTION
I've often found myself wanting to use global() but checking app() instead, and not remembering the name of global(). So, I think this mention would be useful for redirecting users.