### PR TITLE
Fix crash in .get_breaks

### DIFF
--- a/R/plot_helper.R
+++ b/R/plot_helper.R
@@ -188,6 +188,7 @@ hexcols <- function(out) {
 		i <- seq(0, 1, length.out=n)
 		breaks <- quantile(x, i, na.rm=TRUE)
 		breaks <- unique(breaks)
+		n <- min(n, length(breaks))               # adapt when not enough unique values
 		if ((breaks[1] %% 1) != 0) {
 			breaks[1] <- breaks[1] - 0.000001
 		}


### PR DESCRIPTION
When calling `plot` with `breaks = n, breakby = 'cases'` on a SpatRaster with an unusual distribution such that multiple quantiles end up with the same breakpoint, e.g., 
```
  0%  10%  20%  30%  40%  50%  60%  70%  80%  90% 100% 
  87   91   93   94   94   95   96   97   97   99  104 
```
`plot` crashes in `.get_breaks`, e.g.
```
> plot(thedata, col = map.pal('viridis'), breaks = 10, breakby = 'cases')  
 Error in if ((breaks[n]%%1) != 0) { : 
  missing value where TRUE/FALSE needed
```

This happens because when there are ties, `breaks <- unique(breaks)` gives fewer elements than the requested number of breaks `n`, crashing a few lines later on `breaks[n]`. My fix is to add 
```
n <- min(n, length(breaks))
```
after the call to `unique`. This has the effect of merging tied quantiles and displaying a perfectly nice plot.

I'm working with several hundred orthophotos, including single-band shortwave infrared images with only 256 levels and uneven distributions, so I've seen this crash several times.

## Sample data
[test.tif](https://github.com/user-attachments/files/22751400/test.tif)
## Sample code
```
x <- rast('test.tif')
terra::plot(x, breaks = 10, breakby = 'cases') 
```