### PR TITLE
fix modulo in arith-generic.Rd

### DIFF
--- a/man/arith-generic.Rd
+++ b/man/arith-generic.Rd
@@ -65,7 +65,7 @@ x + y
 # intersection
 x * y
 
-e <- x %% 2
+e <- x \%\% 2
 e
 e * 2
 e / 2


### PR DESCRIPTION
In `?"Arith-methods"` this line in the examples doesn't display correctly:

https://github.com/rspatial/terra/blob/f89bc6e4a1be0ac9a8a20dac47bde2e6bc2a6da3/man/arith-generic.Rd#L68

I think the percent sign is treated as a comment in the Rd documentation, so the escape character must be used.