### PR TITLE
bug(build): Can not build on Windows w/ R 4.2 and R 4.1

### DIFF
--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -41,7 +41,16 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      - name: Install macOS system dependencies
+        if: runner.os == 'macOS'
+        run: brew install gdal proj netcdf tbb
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          packages: rspatial/terra, 
-          extra-packages: any::rcmdcheck, any::sessioninfo
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          error-on: '"error"'


### PR DESCRIPTION
👋 terra Team! The Shiny Team has a few Apps that require `{terra}` for our nightly testing. While it isn't a blocker, it'd be nice to remove the false positives involving installation errors for `{terra}` and R 4.1 / 4.2.

We are testing using the same r-lib/actions to install the packages. I've updated the GHA script to test on all Windows versions to reprex the behavior within this PR. (Marking PR as "draft" as it isn't intended to be merged)

Request: If I could get an incantation (or code changes) for `{terra}` to install, I would be most grateful!

Thank you!

cc @karangattu

------------

I believe if terra is able to be installed, then windows binaries will also be created for R 4.1 / 4.2... which also benefits older R windows users.

[PPM+terra](https://packagemanager.posit.co/client/#/repos/cran/packages/terra/overview?search=terra&distribution=windows#package-details): (Must change the OS and R version manually near bottom of page)
<img width="525" height="48" alt="Screenshot 2025-11-13 at 1 34 42 PM" src="https://github.com/user-attachments/assets/ff6bac17-4c43-4735-a745-cdf7d2b0494a" />
<img width="507" height="44" alt="Screenshot 2025-11-13 at 1 35 13 PM" src="https://github.com/user-attachments/assets/2fa3321c-1744-41ec-aba1-5c0a1cd733a2" />
