### PR TITLE
fix: update description for flip parameters

### DIFF
--- a/man/flip.Rd
+++ b/man/flip.Rd
@@ -12,7 +12,7 @@
 \title{Flip or reverse a raster}
 
 \description{
-Flip the values of a SpatRaster by inverting the order of the rows (\code{vertical=TRUE}) or the columns (\code{vertical=FALSE}).
+Flip the values of a SpatRaster by inverting the order of the rows (\code{direction= "vertical"}) or the columns (\code{direction="horizontal"}).
 
 \code{rev} is the same as a horizontal *and* a vertical flip.
 }


### PR DESCRIPTION
Update the description for `flip` to match the actual parameters under "usage". Specifically, replace `vertical = TRUE / FALSE` with `direction = "vertical" / "horizontal"`.

Fixes #2015 