### PR TITLE
fix typos in docs

### DIFF
--- a/man/add_abline.Rd
+++ b/man/add_abline.Rd
@@ -5,7 +5,7 @@
 \title{add vertical and/or horizontal lines to a map made with terra}
 
 \description{ 
-Adaptation of \code{\link[graphics]{abline}} that allows adding a horizonal or vertical lines to a map. This function will place the lines in the locations within the mapped area as delineated by the axes. It is meant to be used when you specifiy your own tick marks, such that \code{\link{add_grid}} does not work.
+Adaptation of \code{\link[graphics]{abline}} that allows adding a horizontal or vertical lines to a map. This function will place the lines in the locations within the mapped area as delineated by the axes. It is meant to be used when you specify your own tick marks, such that \code{\link{add_grid}} does not work.
 
 Also see \code{\link{graticule}}
 }

--- a/man/combineGeoms.Rd
+++ b/man/combineGeoms.Rd
@@ -12,7 +12,7 @@ Combine geometries
 \description{
 Combine the geometries of one SpatVector with those of another. Geometries can be combined based on overlap, shared boundaries and distance (in that order of operation). 
 
-The typical use-case of this method is when you are editing geometries and you have a number of small polygons in one SpatVector that should be part of the geometries of the another SpatVector; perhaps because they were small holes inbetween the borders of two SpatVectors.
+The typical use-case of this method is when you are editing geometries and you have a number of small polygons in one SpatVector that should be part of the geometries of the other SpatVector; perhaps because they were small holes in between the borders of two SpatVectors.
 
 To append SpatVectors use `rbind` and see methods like \code{intersect} and \code{union} for "normal" polygons combinations. 
 }

--- a/man/compare-generics.Rd
+++ b/man/compare-generics.Rd
@@ -44,7 +44,7 @@ Standard comparison and logical operators for computations with SpatRasters. Com
 
 See \code{\link{not.na}} for the inverse of \code{is.na}, and \code{\link{noNA}} to detect cells with missing value across layers.
 
-The \code{compare} and \code{logic} methods implement these operators in a method that can return \code{NA} istead of \code{FALSE} and allows for setting an output filename.
+The \code{compare} and \code{logic} methods implement these operators in a method that can return \code{NA} instead of \code{FALSE} and allows for setting an output filename.
 
 The terra package does not distinguish between \code{NA} (not available) and \code{NaN} (not a number). In most cases this state is represented by \code{NaN}.  
 

--- a/man/flowAccumulation.Rd
+++ b/man/flowAccumulation.Rd
@@ -17,7 +17,7 @@ Computes flow accumulation or the total contributing area in terms of numbers of
 
 \arguments{
   \item{x}{SpatRaster with flow direction, see \code{\link{terrain}}. }
-  \item{weight}{SpatRaster with weight/score daa. For example, cell area or precipitation}  
+  \item{weight}{SpatRaster with weight/score data. For example, cell area or precipitation}  
   \item{filename}{character. Output filename}
   \item{...}{additional arguments for writing files as in \code{\link{writeRaster}}}
 }
@@ -94,7 +94,7 @@ plot(flow_acc1w)
 plot(flow_acc2w)
 
 
-## Application wth example elevation data
+## Application with example elevation data
 
 elev <- rast(system.file('ex/elev.tif',package="terra"))
 flowdir <- terrain(elev,"flowdir")

--- a/man/focal.Rd
+++ b/man/focal.Rd
@@ -28,7 +28,7 @@ Calculate focal ("moving window") values for each cell.
 
 \item{fillvalue}{numeric. The value of the cells in the virtual rows and columns outside of the raster}
 
-\item{expand}{logical. If \code{TRUE}, the value of the cells in the virtual rows and columns outside of the raster are set to be the same as the value on the border. Only available for "build-in" \code{fun}s such as mean, sum, min and max}
+\item{expand}{logical. If \code{TRUE}, the value of the cells in the virtual rows and columns outside of the raster are set to be the same as the value on the border. Only available for "built-in" \code{fun}s such as mean, sum, min and max}
 
 \item{silent}{logical. If \code{TRUE} error messages are printed that may occur when trying \code{fun} to determine the length of the returned value. This can be useful in debugging a \code{fun} that does not work}
 

--- a/man/metags.Rd
+++ b/man/metags.Rd
@@ -33,7 +33,7 @@ You can set arbitrary metadata to (layers of) a SpatRaster using "name=value", o
 \item{domain}{character. Only used if not specified by \code{value}. Use "" for the default domain. Depending on the file format used this may the only domain supported when writing files}
 \item{name}{character}
 \item{value}{character of "name=value" or two-column (name, value) or three-column (name, value, domain) matrix or data.frame}
-\item{dataset}{NULL, positive integer or character. If the value is NULL, the tags assigned or returned are for the SpatRasterDataset/SpatRasterCollection. Otherwise for the datset number(s) or name(s)}
+\item{dataset}{NULL, positive integer or character. If the value is NULL, the tags assigned or returned are for the SpatRasterDataset/SpatRasterCollection. Otherwise for the dataset number(s) or name(s)}
 }
 
 \value{

--- a/man/nseg.Rd
+++ b/man/nseg.Rd
@@ -7,7 +7,7 @@
 \title{Number of segments}
 
 \description{
-Count the number of segements in a SpatVector of lines or polygons
+Count the number of segments in a SpatVector of lines or polygons
 }
 
 \usage{

--- a/man/pairs.Rd
+++ b/man/pairs.Rd
@@ -36,7 +36,7 @@ s <- c(r, 1/r, sqrt(r))
 names(s) <- c("elevation", "inverse", "sqrt") 
 pairs(s)
 
-# to make indvidual histograms:
+# to make individual histograms:
 hist(r)
 # or scatter plots:
 plot(s[[1]], s[[2]])

--- a/man/pitfinder.Rd
+++ b/man/pitfinder.Rd
@@ -16,7 +16,7 @@ find pits (depressions with no outlet )
 }
 
 \arguments{
-  \item{x}{SpatRaster wih flow-direcion. See \code{\link{terrain}}}
+  \item{x}{SpatRaster with flow-direction. See \code{\link{terrain}}}
   \item{filename}{character. Output filename}
   \item{...}{additional arguments for writing files as in \code{\link{writeRaster}}}  
 }
@@ -62,7 +62,7 @@ t(array(flowdir[],rev(dim(flowdir)[1:2])))
 
 pits <- pitfinder(flowdir)
 
-## Application wth example DEM
+## Application with example DEM
 
 elev <- rast(system.file('ex/elev.tif',package="terra"))
 flowdir <- terrain(elev,"flowdir")

--- a/man/split.Rd
+++ b/man/split.Rd
@@ -25,7 +25,7 @@ Split a SpatRaster by layer, or a SpatVector by attributes. You can also split t
 \arguments{
   \item{x}{SpatRaster or SpatVector}
   \item{f}{If \code{x} is a SpatRaster: a vector of the length \code{nlyr(x)}. If \code{x} is a SpatVector: one or more variable names, or a vector of the same length as \code{x}, or a list of such vectors. If \code{x} is a SpatVector of polygons, you can also use a SpatVector of lines or polygons to split the polygon geometries}
-  \item{min_node_dist}{postive number indicating the minimum node distance to use (in m) for longitude/latitude data. To ensure this minium distance between nodes, additional nodes are added as needed, to improve precision. See \code{\link{densify}}}
+  \item{min_node_dist}{positive number indicating the minimum node distance to use (in m) for longitude/latitude data. To ensure this minimum distance between nodes, additional nodes are added as needed, to improve precision. See \code{\link{densify}}}
 }
 
 \value{

--- a/man/terra-package.Rd
+++ b/man/terra-package.Rd
@@ -186,7 +186,7 @@ Apart from the function listed below, you can also use indexing with \code{[} wi
     \code{\link{setValues}} \tab Set new values to the cells of a SpatRaster \cr
     \code{\link{as.matrix}} \tab Get cell values as a matrix \cr
     \code{\link{as.array}} \tab Get cell values as an array \cr
-	\code{\link{as.data.frame}} \tab get cell values as a data.frame (including class lables)\cr
+	\code{\link{as.data.frame}} \tab get cell values as a data.frame (including class labels)\cr
     \code{\link{extract}} \tab Extract cell values from a SpatRaster (with cell numbers, coordinates, points, lines, or polygons)\cr
     \code{\link{extractAlong}} \tab Extract cell values along a line such that the values are in the right order\cr
     \code{\link{spatSample}} \tab Take a sample (regular, random, stratified, weighted) sample from a SpatRaster\cr

--- a/man/varnames.Rd
+++ b/man/varnames.Rd
@@ -22,7 +22,7 @@
 \description{
 Set or get names for each dataset (variable) in a SpatRasterDataset. 
 
-Each SpatRaster _data source_ can also have a variable name and a long variable name. They are set when reading a file with possibly multiple sub-datasets (e.g. netcdf or hdf5 format) into a single SpatRaster. Each sub-datset is a seperate "data-source" in the SpatRaster. Note that newly created or derived SpatRasters always have a single variable (data source), and therefore the variable names are lost when processing a multi-variable SpatRaster. Thus the variable names are mostly useful to understand a SpatRaster created from some files and for managing SpatRasterDatasets.
+Each SpatRaster _data source_ can also have a variable name and a long variable name. They are set when reading a file with possibly multiple sub-datasets (e.g. netcdf or hdf5 format) into a single SpatRaster. Each sub-dataset is a separate "data-source" in the SpatRaster. Note that newly created or derived SpatRasters always have a single variable (data source), and therefore the variable names are lost when processing a multi-variable SpatRaster. Thus the variable names are mostly useful to understand a SpatRaster created from some files and for managing SpatRasterDatasets.
 
 See \code{link{names}} for the more commonly used _layer_ names.
 

--- a/man/writeCDF.Rd
+++ b/man/writeCDF.Rd
@@ -15,7 +15,7 @@ Always use the \code{".nc"} or \code{".cdf"} file extension to assure that the f
 
 You can write multiple rasters (variables) that are two (x, y), three (x, y, z or x, y, time) or four dimensional (x, y, z, time).
 
-See \code{\link{depth}} and \code{\link{time}} for specifying the axes of the thrid and/or fourth dimension(s).
+See \code{\link{depth}} and \code{\link{time}} for specifying the axes of the third and/or fourth dimension(s).
 }
 
 \usage{


### PR DESCRIPTION
Hi there,

I conducted a thorough review of the documentation in the `man/` directory and fixed several typos.