### PR TITLE
CSLConstList compat for GDAL 3.13

### DIFF
--- a/src/RcppFunctions.cpp
+++ b/src/RcppFunctions.cpp
@@ -296,7 +296,7 @@ std::vector<std::vector<std::string>> gdal_drivers() {
 	size_t n = GetGDALDriverManager()->GetDriverCount();
 	std::vector<std::vector<std::string>> s(6, std::vector<std::string>(n));
     GDALDriver *poDriver;
-    char **papszMetadata;
+    CSLConstList papszMetadata;
 	for (size_t i=0; i<n; i++) {
 	    poDriver = GetGDALDriverManager()->GetDriver((int)i);
 		const char* ss = poDriver->GetDescription();

--- a/src/gdalio.cpp
+++ b/src/gdalio.cpp
@@ -130,7 +130,7 @@ std::vector<std::string> get_metadata(std::string filename) {
 		return out;
 	}
 
-	char **m = poDataset->GetMetadata();
+  CSLConstList m = poDataset->GetMetadata();
 	if (m != NULL) {
 		while (*m != nullptr) {
 			out.push_back(*m++);
@@ -147,7 +147,7 @@ std::vector<std::string> get_metadata_sds(std::string filename) {
     if( poDataset == NULL )  {
 		return meta;
 	}
-	char **metadata = poDataset->GetMetadata("SUBDATASETS");
+  CSLConstList metadata = poDataset->GetMetadata("SUBDATASETS");
 	if (metadata != NULL) {
 		for (size_t i=0; metadata[i] != NULL; i++) {
 			meta.push_back(metadata[i]);
@@ -249,7 +249,7 @@ std::vector<std::vector<std::string>> sdinfo(std::string fname) {
 		}
 		return out;
 	}
-	char **metadata = poDataset->GetMetadata("SUBDATASETS");
+  CSLConstList metadata = poDataset->GetMetadata("SUBDATASETS");
 	if (metadata == NULL) {
 		out[0] = std::vector<std::string> {"no subdatasets"};
 		GDALClose( (GDALDatasetH) poDataset );

--- a/src/read_gdal.cpp
+++ b/src/read_gdal.cpp
@@ -623,7 +623,7 @@ std::vector<std::string> get_metadata(std::string filename, std::vector<std::str
     if( poDataset == NULL )  {
 		return metadata;
 	}
-	char **m = poDataset->GetMetadata();
+	CSLConstList m = poDataset->GetMetadata();
 	if (m) {
 		while (*m != nullptr) {
 			metadata.push_back(*m++);
@@ -647,7 +647,7 @@ SpatRasterStack::SpatRasterStack(std::string fname, std::vector<int> ids, bool u
 	}
 
 	std::string delim = "NAME=";
-	char **metadata = poDataset->GetMetadata("SUBDATASETS");
+	CSLConstList metadata = poDataset->GetMetadata("SUBDATASETS");
 
 	if (metadata == NULL) {
 		GDALClose( (GDALDatasetH) poDataset );
@@ -695,7 +695,7 @@ SpatRasterStack::SpatRasterStack(std::string fname, std::vector<int> ids, bool u
 		}
 	}
 	meta.resize(0);
-	char **m = poDataset->GetMetadata();
+	CSLConstList m = poDataset->GetMetadata();
 	if (m) {
 		while (*m != nullptr) {
 			meta.push_back(*m++);
@@ -725,7 +725,7 @@ SpatRasterCollection::SpatRasterCollection(std::string fname, std::vector<int> i
 	}
 
 	std::string delim = "NAME=";
-	char **metadata = poDataset->GetMetadata("SUBDATASETS");
+	CSLConstList metadata = poDataset->GetMetadata("SUBDATASETS");
 
 	if (metadata == NULL) {
 		GDALClose( (GDALDatasetH) poDataset );
@@ -770,7 +770,7 @@ SpatRasterCollection::SpatRasterCollection(std::string fname, std::vector<int> i
 		}
 	}
 	meta.resize(0);
-	char **m = poDataset->GetMetadata();
+	CSLConstList m = poDataset->GetMetadata();
 	if (m) {
 		while (*m != nullptr) {
 			meta.push_back(*m++);
@@ -886,7 +886,7 @@ bool SpatRaster::constructFromFile(std::string fname, std::vector<int> subds, st
 	int nl = poDataset->GetRasterCount();
 	std::string gdrv = poDataset->GetDriver()->GetDescription();
 
-	char **metasds = poDataset->GetMetadata("SUBDATASETS");
+	CSLConstList metasds = poDataset->GetMetadata("SUBDATASETS");
 	
 	if (metasds != NULL) {
 		std::vector<std::string> meta;
@@ -902,7 +902,7 @@ bool SpatRaster::constructFromFile(std::string fname, std::vector<int> subds, st
 	}
 
 	for (size_t i=0; i<domains.size(); i++) {
-		char **meterra = poDataset->GetMetadata(domains[i].c_str());
+	  CSLConstList meterra = poDataset->GetMetadata(domains[i].c_str());
 		if (meterra != NULL) {
 			std::vector<std::string> meta;
 			for (size_t j=0; meterra[j] != NULL; j++) {
@@ -919,7 +919,7 @@ bool SpatRaster::constructFromFile(std::string fname, std::vector<int> subds, st
 	
 	SpatRasterSource s;
 
-	char **metasrc = poDataset->GetMetadata();
+	CSLConstList metasrc = poDataset->GetMetadata();
 	while (metasrc != nullptr && *metasrc != nullptr) {
 		s.smdata.push_back(*metasrc++);
 	}
@@ -1065,7 +1065,7 @@ bool SpatRaster::constructFromFile(std::string fname, std::vector<int> subds, st
 		}
 
 		// if ((gdrv=="netCDF") || (gdrv == "HDF5") || (gdrv == "GRIB") || (gdrv == "GTiff")) {
-			char **m = poBand->GetMetadata();
+		  CSLConstList m = poBand->GetMetadata();
 			while (m != nullptr && *m != nullptr) {
 				bandmeta[i].push_back(*m++);
 			}
@@ -1073,7 +1073,7 @@ bool SpatRaster::constructFromFile(std::string fname, std::vector<int> subds, st
 			//	Rcpp::Rcout << bandmeta[i][j] << std::endl;
 			//}
 			
-			char **meterra = poBand->GetMetadata("USER_TAGS");
+			CSLConstList meterra = poBand->GetMetadata("USER_TAGS");
 			if (meterra != NULL) {
 //				std::vector<std::string> meta;
 				for (size_t j=0; meterra[j] != NULL; j++) {
@@ -1302,7 +1302,7 @@ bool SpatRaster::constructFromFile(std::string fname, std::vector<int> subds, st
 
 	if ((gdrv=="netCDF") || (gdrv == "HDF5"))  {
 		
-		char **m = poDataset->GetMetadata();
+		CSLConstList m = poDataset->GetMetadata();
 		if (m) {
 			while (*m != nullptr) {
 				metadata.push_back(*m++);

--- a/src/write_gdal.cpp
+++ b/src/write_gdal.cpp
@@ -362,7 +362,7 @@ bool SpatRaster::writeStartGDAL(SpatOptions &opt, const std::vector<std::string>
 		}
 	}
 	
-    char **papszMetadata;
+	  CSLConstList papszMetadata;
     papszMetadata = poDriver->GetMetadata();
     if (!CSLFetchBoolean( papszMetadata, GDAL_DCAP_RASTER, FALSE)) {
 		setError(driver + " is not a raster format");

--- a/src/write_ogr.cpp
+++ b/src/write_ogr.cpp
@@ -106,7 +106,7 @@ GDALDataset* SpatVector::write_ogr(std::string filename, std::string lyrname, st
 			setError( driver + " driver not available");
 			return poDS;
 		}
-		char **papszMetadata;
+		CSLConstList papszMetadata;
 		papszMetadata = poDriver->GetMetadata();
 		if (!CSLFetchBoolean( papszMetadata, GDAL_DCAP_VECTOR, FALSE)) {
 			setError(driver + " is not a vector format");


### PR DESCRIPTION
GDAL 3.13 requires  `CSLConstList` for `GetMetadata`

https://github.com/OSGeo/gdal/pull/13658

```R
 terra::gdal()
[1] "3.13.0dev-7924dc998e"
```

I've been using this upcoming version extensively with gdalraster and terra and vapour. 


```
✔  checking compiled code (335ms)
─  checking examples ... [61s/61s] OK (1m 2.1s)
   Examples with CPU (user + system) or elapsed time > 5s
            user system elapsed
   predict 2.944  4.008   0.267
   animate 0.564  0.001  10.326
✔  checking for unstated dependencies in ‘tests’ ...
─  checking tests ...
✔  Running ‘tinytest.R’
✔  checking for non-standard things in the check directory
✔  checking for detritus in the temp directory
   
   See
     ‘/perm_storage/home/mdsumner/Git/terra.Rcheck/00check.log’
   for details.
   
── R CMD check results ───────────────────────────────── terra 1.8-96 ────
Duration: 5m 26.3s

❯ checking for future file timestamps ... NOTE
  unable to verify current time

0 errors ✔ | 0 warnings ✔ | 1 note ✖

R CMD check succeeded
```