### PR TITLE
--run-dontrun errors; plet completed, regress and possibly others remain

### DIFF
--- a/R/plot_let.R
+++ b/R/plot_let.R
@@ -885,7 +885,7 @@ setMethod("plet", signature(x="SpatRaster"),
 			if (panel) {
 				#map <- leaflet::addCircleMarkers(map, data=p, label=p$label, radius=1, opacity=1, col="red")
 				map <- leaflet::addLabelOnlyMarkers(map, label=p$label, data=p, 
-                      labelOptions = leaflet::labelOptions(noHide = T, textOnly = T))
+                      labelOptions = leaflet::labelOptions(noHide = TRUE, textOnly = TRUE))
 			}
 		} else {
 			nms <- make.unique(names(x))

--- a/man/plet.Rd
+++ b/man/plet.Rd
@@ -116,15 +116,15 @@ The arguments of \code{plet} are similar to those of \code{\link[terra]{plot}}, 
 if (require(leaflet) && (packageVersion("leaflet") > "2.1.1")) {
 
 v <- vect(system.file("ex/lux.shp", package="terra"))
-p <- spatSample(as.polygons(v, ext=T), 30)
+p <- spatSample(as.polygons(v, ext=TRUE), 30)
 values(p) = data.frame(id=11:40, name=sample(letters, 30, replace=TRUE))
 
 m <- plet(v, "NAME_1", tiles="", border="blue")
-m <- points(m, p, col="red", cex=2, popup=T)
+m <- points(m, p, col="red", cex=2, popup=TRUE)
 lines(m, v, lwd=1, col="white")
 
 # color by the values of a variable
-plet(v, tiles="") |> points(p, field="name", cex=8)
+plet(v, tiles="") |> points(p, cex=8)
 
 plet(v, "NAME_1", split=TRUE, alpha=.2) |> 
   points(p, col="white", border="red", cex=12, popup=TRUE, lwd=3, lty="1 4",


### PR DESCRIPTION
Running R CMD check --run_dontrun --run-donttest with the HEAD of the repo (checking the fix for the GEOS problem, whiich is now resolved), I have found --run-dontrun errors. I corrected that for `plet` (`T` for `TRUE`), but cannot see how to fix that for regress. Log for prior status:

[00check.log](https://github.com/user-attachments/files/29959491/00check.log),

and for current status with `plet` fixed:

[00check.log](https://github.com/user-attachments/files/29959540/00check.log)
