### PR TITLE
Handle NaN to enforce weak ordering in sort in transverse_deviation

### DIFF
--- a/src/catchments.cpp
+++ b/src/catchments.cpp
@@ -1085,8 +1085,12 @@ bool transverse_deviation(double *e, double *tdc, double *tdd,double *sr,double 
   /// ORDER E ; 
   std::vector<int> ide(ncell,0);
   std::iota(ide.begin(), ide.end(), 0); 
-  std::sort(ide.begin(), ide.end(),[&](int a, int b){ return e[a] > e[b]; });
-  
+  std::sort(ide.begin(), ide.end(), [&](int a, int b) {
+	if (std::isnan(e[a])) return false;
+	if (std::isnan(e[b])) return true;
+	return e[a] > e[b];
+  });
+
   for (int i = 0; i < ncell; i++) {
     
     *(has_upstream+i)=0;


### PR DESCRIPTION
Closes #2168. Suggested by Gemini, it looks right to me (especially it matches the lambda in sort.cpp), and the examples work+tests pass with it applied.

Given that existing examples already failed, I elected not to add any new tests, but we _could_ add some in principle.