### PR TITLE
gdal_has_pam() to query PAM support

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -20,4 +20,4 @@ S3method(str, SpatRaster)
 S3method(str, SpatExtent)
 S3method(str, SpatGraticule)
 
-export(add_abline, add_box, add_legend, add_grid, add_mtext, legend_cont, ar_info, clearVSIcache, combineLevels, focalMat, extractAlong, gdal, getGDALconfig, graticule, halo, libVersion, proj_ok, projNetwork, projPaths, setGDALconfig, map.pal, map_extent, north, sbar, terraOptions, tile_apply, tmpFiles, makeVRT, mem_info, free_RAM, same.crs, proj_pipelines, shade, gdalCache, fileBlocksize, vector_layers, vrt_tiles, names, round, unloadGDALdrivers, warp_scale, make.RGB, as.arrows)
+export(add_abline, add_box, add_legend, add_grid, add_mtext, legend_cont, ar_info, clearVSIcache, combineLevels, focalMat, extractAlong, gdal, getGDALconfig, gdal_has_pam, graticule, halo, libVersion, proj_ok, projNetwork, projPaths, setGDALconfig, map.pal, map_extent, north, sbar, terraOptions, tile_apply, tmpFiles, makeVRT, mem_info, free_RAM, same.crs, proj_pipelines, shade, gdalCache, fileBlocksize, vector_layers, vrt_tiles, names, round, unloadGDALdrivers, warp_scale, make.RGB, as.arrows)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -65,6 +65,10 @@ rgb2hex <- function(x) {
     .Call(`_terra_gdal_version`)
 }
 
+.gdal_build_info <- function() {
+    .Call(`_terra_gdal_build_info`)
+}
+
 .geos_version <- function(runtime = FALSE, capi = FALSE) {
     .Call(`_terra_geos_version`, runtime, capi)
 }

--- a/R/gdal.R
+++ b/R/gdal.R
@@ -138,6 +138,10 @@ gdal <- function(warn=NA, drivers=FALSE, ...) {
 
 
 
+gdal_has_pam <- function() grepl("PAM_ENABLED=YES", .gdal_build_info())
+
+
+
 .describe_sds <- function(x, print=FALSE) {
 	x <- .sdinfo(x)
 	if (length(x[[1]]) == 1 & length(x[[2]]) == 0) {

--- a/inst/tinytest/test_cats.R
+++ b/inst/tinytest/test_cats.R
@@ -18,20 +18,22 @@ r <- droplevels(r)
 expect_equal(levels(r)[[1]][,2], c("forest", "water", "urban"))
 lv <- lv[-4,]
 
-# reading/writing categories
-ftmp <- tempfile(fileext = ".tif")
-z <- writeRaster(r, ftmp, overwrite=TRUE)
-v <- cats(z)[[1]]
-expect_equal(v$value, 1:3)
-expect_equal(v$`land cover`, lv[,2])
+if (gdal_has_pam()) {
+  # reading/writing categories
+  ftmp <- tempfile(fileext = ".tif")
+  z <- writeRaster(r, ftmp, overwrite=TRUE)
+  v <- cats(z)[[1]]
+  expect_equal(v$value, 1:3)
+  expect_equal(v$`land cover`, lv[,2])
 
-# reading/writing subset of categories
-levels(r) = cats(r)[[1]][2:3,]
-zz = writeRaster(r, ftmp, overwrite=TRUE)
-v <- cats(zz)[[1]]
+  # reading/writing subset of categories
+  levels(r) = cats(r)[[1]][2:3,]
+  zz = writeRaster(r, ftmp, overwrite=TRUE)
+  v <- cats(zz)[[1]]
 
-expect_equal(v$value, 2:3)
-expect_equal(v$cover, lv[-1,2])
+  expect_equal(v$value, 2:3)
+  expect_equal(v$cover, lv[-1,2])
+}
 
 # categories in multiple layers
 r2 <- rast(list(a=r0, b=r0))

--- a/man/gdal.Rd
+++ b/man/gdal.Rd
@@ -6,6 +6,7 @@
 \alias{clearVSIcache}
 \alias{getGDALconfig}
 \alias{setGDALconfig}
+\alias{gdal_has_pam}
 \alias{unloadGDALdrivers}
 \alias{proj_ok}
 \alias{projNetwork}
@@ -21,6 +22,8 @@ Set the \code{GDAL} warning level or get a \code{data.frame} with the available 
 
 The current \code{GDAL} configuration options are obtained with \code{getGDALconfig} and changed with \code{setGDALconfig}. 
 
+\code{gdal_has_pam} reports whether the linked GDAL was built with PAM support.
+
 \code{proj_ok} checks if the PROJ database with CRS definitions can be found.
 
 \code{projNetwork} controls whether PROJ can access network resources for coordinate transformations. By default, network access is enabled to provide high-accuracy grid-based datum transformations where available. When disabled, PROJ falls back to \href{https://proj.org/en/stable/glossary.html#term-Ballpark-transformation}{"ballpark transformations"} (of unknown accuracy) which could lead to errors of hundreds of meters in some cases. When enabled, PROJ downloads transformation grids from \code{https://cdn.proj.org}, requiring network connectivity and valid SSL certificates. After a successful run, the files are cached locally.
@@ -33,6 +36,7 @@ gdal(warn=NA, drivers=FALSE, ...)
 gdalCache(size=NA)
 setGDALconfig(option, value="")
 getGDALconfig(option)
+gdal_has_pam()
 clearVSIcache()
 libVersion(lib="all", parse=FALSE)
 unloadGDALdrivers(x)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -185,6 +185,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// gdal_build_info
+std::string gdal_build_info();
+RcppExport SEXP _terra_gdal_build_info() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(gdal_build_info());
+    return rcpp_result_gen;
+END_RCPP
+}
 // geos_version
 std::string geos_version(bool runtime, bool capi);
 RcppExport SEXP _terra_geos_version(SEXP runtimeSEXP, SEXP capiSEXP) {
@@ -498,6 +508,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_terra_gmdinfo", (DL_FUNC) &_terra_gmdinfo, 2},
     {"_terra_sd_info", (DL_FUNC) &_terra_sd_info, 1},
     {"_terra_gdal_version", (DL_FUNC) &_terra_gdal_version, 0},
+    {"_terra_gdal_build_info", (DL_FUNC) &_terra_gdal_build_info, 0},
     {"_terra_geos_version", (DL_FUNC) &_terra_geos_version, 2},
     {"_terra_metatdata", (DL_FUNC) &_terra_metatdata, 1},
     {"_terra_sdsmetatdata", (DL_FUNC) &_terra_sdsmetatdata, 1},

--- a/src/RcppFunctions.cpp
+++ b/src/RcppFunctions.cpp
@@ -274,6 +274,14 @@ std::string gdal_version() {
 	return s;
 }
 
+// [[Rcpp::export(name = ".gdal_build_info")]]
+std::string gdal_build_info() {
+	const char* what = "BUILD_INFO";
+	const char* x = GDALVersionInfo(what);
+	std::string s = (std::string) x;
+	return s;
+}
+
 // [[Rcpp::export(name = ".geos_version")]]
 std::string geos_version(bool runtime = false, bool capi = false) {
 	if (runtime)


### PR DESCRIPTION
Closes #2170. Just a possible solution -- I didn't see an easy way to shoehorn this into the existing API so it adds an export. That export could just as well be `gdal_build_info()` and the test itself does `grepl()`.

Depending on your tastes, we could also leave everything un-exported and just have `terra:::gdal_has_pam()` (etc) in the test suite. Unlike {testthat}, {tinytest} does _not_ expose private namespace symbols to the test suite, so `:::` would be required.