### PR TITLE
crop.Rd: clarify 'snap' argument description

### DIFF
--- a/man/crop.Rd
+++ b/man/crop.Rd
@@ -37,7 +37,7 @@ You can crop a SpatVector with another SpatVector. If these are not polygons, th
 \arguments{
   \item{x}{SpatRaster or SpatVector}
   \item{y}{SpatRaster, SpatVector, SpatExtent, or any other object that has a SpatExtent (\code{\link{ext}} returns a \code{SpatExtent})}
-  \item{snap}{character. One of "near", "in", or "out". Used to align \code{y} to the geometry of \code{x}, i.e. to determine how the \code{x} raster grid is cropped with the bounding box of \code{y} (independently of \code{mask} and \code{touches})} 
+  \item{snap}{character. One of "near", "in", or "out". Used to align SpatExtent \code{y} to the geometry (cells) of \code{x}. You can snap the extent to the nearest cell boundaries; to the nearest cell boundaries that are inside the extent; or to the nearest cell boundaries that are outside the extent. This works independently of arguments \code{mask} and \code{touches})} 
   \item{mask}{logical. Should \code{y} be used to mask? Only used if \code{y} is a SpatVector, SpatRaster or sf}  
   \item{touches}{logical. If \code{TRUE} and \code{mask=TRUE}, all cells touched by lines or polygons will be masked, not just those on the line render path, or whose center point is within the polygon}
   \item{extend}{logical. Should rows and/or columns be added if \code{y} is beyond the extent of \code{x}? Also see \code{\link{extend}}}  

--- a/man/crop.Rd
+++ b/man/crop.Rd
@@ -37,7 +37,7 @@ You can crop a SpatVector with another SpatVector. If these are not polygons, th
 \arguments{
   \item{x}{SpatRaster or SpatVector}
   \item{y}{SpatRaster, SpatVector, SpatExtent, or any other object that has a SpatExtent (\code{\link{ext}} returns a \code{SpatExtent})}
-  \item{snap}{character. One of "near", "in", or "out". Used to align \code{y} to the geometry of \code{x}} 
+  \item{snap}{character. One of "near", "in", or "out". Used to align \code{y} to the geometry of \code{x}, i.e. to determine how the \code{x} raster grid is cropped with the bounding box of \code{y} (independently of \code{mask} and \code{touches})} 
   \item{mask}{logical. Should \code{y} be used to mask? Only used if \code{y} is a SpatVector, SpatRaster or sf}  
   \item{touches}{logical. If \code{TRUE} and \code{mask=TRUE}, all cells touched by lines or polygons will be masked, not just those on the line render path, or whose center point is within the polygon}
   \item{extend}{logical. Should rows and/or columns be added if \code{y} is beyond the extent of \code{x}? Also see \code{\link{extend}}}  


### PR DESCRIPTION
The role of `snap` is often confused with `touches`, and the current description of `snap` is a bit unclear. But please feel free to edit my edit if still unclear or inaccurate :)